### PR TITLE
Update to Solana SDK 3.0, remove Turnkey

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,12 @@
 
 # ==== REQUIRED CONFIGURATION ====
 # RPC_URL: Required for all recipes and ingredients
-RPC_URL="https://api.devnet.solana.com"
+# 
+# For local validator (recommended while devnet support is temporarily disabled):
+RPC_URL="http://localhost:8899"
+#
+# For devnet (when confidential balances support is re-enabled):
+# RPC_URL="https://api.devnet.solana.com"
 
 # ==== RECOMMENDED CONFIGURATION ====
 # While not strictly required (will be auto-generated if missing), 
@@ -10,17 +15,6 @@ RPC_URL="https://api.devnet.solana.com"
 # This prevents you from having to fund a new fee payer each time runtime_output.env is deleted.
 # The auto-generated fee payer will be stored in runtime_output.env, not .env.
 fee_payer_keypair=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-
-# ==== TURNKEY INTEGRATION (Optional) ====
-# Required only when running basic_transfer_recipe_turnkey
-# Can be omitted if not using Turnkey functionality
-TURNKEY_API_PUBLIC_KEY="your_api_public_key"
-TURNKEY_API_PRIVATE_KEY="your_api_private_key"
-TURNKEY_ORGANIZATION_ID="your_organization_id"
-TURNKEY_SENDER_PRIVATE_KEY_ID="your_solana_sender_private_key_id"
-TURNKEY_SENDER_PUBLIC_KEY="your_solana_sender_public_key"
-TURNKEY_RECEIVER_PRIVATE_KEY_ID="your_solana_receiver_private_key_id"
-TURNKEY_RECEIVER_PUBLIC_KEY="your_solana_receiver_public_key"
 
 # ==== GOOGLE CLOUD KMS INTEGRATION (Optional) ====
 # Required only when running basic_transfer_recipe_gcp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,24 +1,4 @@
 {
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#e46445",
-        "activityBar.background": "#e46445",
-        "activityBar.foreground": "#15202b",
-        "activityBar.inactiveForeground": "#15202b99",
-        "activityBarBadge.background": "#58e774",
-        "activityBarBadge.foreground": "#15202b",
-        "commandCenter.border": "#e7e7e799",
-        "sash.hoverBorder": "#e46445",
-        "statusBar.background": "#d7431f",
-        "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#e46445",
-        "statusBarItem.remoteBackground": "#d7431f",
-        "statusBarItem.remoteForeground": "#e7e7e7",
-        "titleBar.activeBackground": "#d7431f",
-        "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveBackground": "#d7431f99",
-        "titleBar.inactiveForeground": "#e7e7e799"
-    },
-    "peacock.color": "#d7431f",
     "files.associations": {
         "runtime_output.env": "properties"
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,13 +55,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "agave-transaction-view"
-version = "2.1.11"
+name = "agave-feature-set"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733fd6e7b3734f2a019ddd1ce57643439190e3f43274d466d425e3b719802212"
+checksum = "53e0d37e3232be339a6a19a376c7696458b6a8183e95bf806709fad71595010b"
 dependencies = [
- "solana-sdk",
- "solana-svm-transaction",
+ "ahash",
+ "solana-epoch-schedule",
+ "solana-hash 3.1.0",
+ "solana-pubkey 3.0.0",
+ "solana-sha256-hasher",
+ "solana-svm-feature-set",
+]
+
+[[package]]
+name = "agave-reserved-account-keys"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c651f94dc123e67cacfcf320b686aaaf8daf7910a263982ab806fe50ae197eb0"
+dependencies = [
+ "agave-feature-set",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
 ]
 
 [[package]]
@@ -111,12 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,150 +136,29 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "apply_pending_balance"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "spl-associated-token-account 6.0.0",
- "spl-token-2022 7.0.0",
+ "spl-associated-token-account",
+ "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-client",
  "utils",
 ]
 
 [[package]]
-name = "aquamarine"
-version = "0.3.3"
+name = "arc-swap"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
+checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
 dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "derivative",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-serialize-derive",
- "ark-std",
- "digest 0.10.7",
- "num-bigint 0.4.6",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
+ "rustversion",
 ]
 
 [[package]]
@@ -340,23 +219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,11 +234,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -405,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -485,31 +347,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -560,12 +401,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
+name = "bitvec"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "typenum",
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -579,16 +423,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
+ "digest",
 ]
 
 [[package]]
@@ -601,71 +436,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "0.10.4"
+name = "blst"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
- "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "blstrs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
- "borsh-derive 1.5.5",
+ "borsh-derive",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
-dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b668d39970baad5356d7c83a86fee3a539e6f93bf6764c97368243e17a0487"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -721,19 +539,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.21.0"
+name = "byte-slice-cast"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -748,29 +572,11 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "serde",
 ]
 
 [[package]]
@@ -802,9 +608,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -825,26 +631,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "chrono-humanize"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
-dependencies = [
- "chrono",
+ "windows-link",
 ]
 
 [[package]]
@@ -918,23 +714,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
+name = "console"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
-dependencies = [
- "log",
- "web-sys",
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -954,6 +743,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -985,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1018,12 +817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
-
-[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,35 +840,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1087,7 +857,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rand_core 0.6.4",
  "rustc_version",
@@ -1153,7 +923,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
- "rayon",
 ]
 
 [[package]]
@@ -1167,8 +936,8 @@ name = "deposit_tokens"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "spl-associated-token-account 6.0.0",
- "spl-token-2022 7.0.0",
+ "spl-associated-token-account",
+ "spl-token-2022",
  "utils",
 ]
 
@@ -1179,7 +948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1213,41 +981,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
- "console",
+ "console 0.15.10",
  "shell-words",
  "tempfile",
  "zeroize",
-]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1256,19 +998,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dir-diff"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
-dependencies = [
- "walkdir",
 ]
 
 [[package]]
@@ -1333,12 +1066,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,58 +1078,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
  "spki",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "signature 1.6.4",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.9.9",
+ "sha2",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ed25519-dalek-bip32"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
+checksum = "6b49a684b133c4980d7ee783936af771516011c8cd15f429dbda77245e282f03"
 dependencies = [
  "derivation-path",
  "ed25519-dalek",
- "hmac 0.12.1",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "educe"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "hmac",
+ "sha2",
 ]
 
 [[package]]
@@ -1419,11 +1136,10 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1467,32 +1183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-ordinalize"
-version = "3.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,12 +1197,6 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
@@ -1531,8 +1215,20 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.1",
+ "libm",
+ "rand 0.9.2",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -1549,10 +1245,11 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1564,22 +1261,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "filetime"
-version = "0.2.25"
+name = "five8"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "a75b8549488b4715defcb0d8a8a1c1c76a80661b5fa106b4ca0e7fce59d7d875"
 dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
+ "five8_core",
+]
+
+[[package]]
+name = "five8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
+dependencies = [
+ "five8_core",
 ]
 
 [[package]]
 name = "five8_const"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
  "five8_core",
 ]
@@ -1598,15 +1301,6 @@ checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1632,18 +1326,18 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
-name = "fragile"
+name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1746,7 +1440,6 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
  "zeroize",
@@ -1760,19 +1453,6 @@ checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1795,16 +1475,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "glob"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "global_auditor_assert"
@@ -1812,10 +1494,11 @@ version = "0.1.0"
 dependencies = [
  "bs58 0.5.1",
  "solana-client",
+ "solana-commitment-config",
  "solana-sdk",
  "solana-transaction-status-client-types",
- "spl-token-2022 7.0.0",
- "spl-token-confidential-transfer-proof-generation 0.3.0",
+ "spl-token-2022",
+ "spl-token-confidential-transfer-proof-generation",
  "utils",
 ]
 
@@ -1831,7 +1514,7 @@ dependencies = [
  "google-cloud-token",
  "home",
  "jsonwebtoken",
- "reqwest 0.12.12",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1891,7 +1574,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
 dependencies = [
- "reqwest 0.12.12",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -1932,7 +1615,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
+ "rand 0.8.5",
  "rand_core 0.6.4",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -1948,10 +1633,10 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1967,18 +1652,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -1991,30 +1676,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hermit-abi"
@@ -2027,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2045,32 +1715,11 @@ checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
 name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array",
- "hmac 0.8.1",
+ "digest",
 ]
 
 [[package]]
@@ -2152,9 +1801,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -2173,7 +1822,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -2182,13 +1831,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",
@@ -2196,23 +1846,10 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2223,13 +1860,14 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.22",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tower-service",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -2238,7 +1876,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2266,7 +1904,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2276,21 +1914,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.8.1",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2442,9 +2087,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2462,47 +2107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "rayon",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "index_list"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa38453685e5fe724fd23ff6c1a158c1e2ca21ce0c2718fa11e96e70e99fd4de"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,24 +2118,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.2",
  "portable-atomic",
  "unicode-width 0.2.0",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2551,12 +2155,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
+name = "iri-string"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
- "either",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2601,16 +2206,18 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine 4.6.7",
  "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2669,6 +2276,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,9 +2306,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -2697,67 +2324,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "hmac-drbg",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "light-poseidon"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "num-bigint 0.4.6",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2784,28 +2350,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lz4"
-version = "1.28.1"
+name = "lru-slab"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
-dependencies = [
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -2818,15 +2371,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memoffset"
@@ -2856,16 +2400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,10 +2419,9 @@ name = "mint_tokens"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "solana-zk-sdk",
- "spl-associated-token-account 6.0.0",
- "spl-token-2022 7.0.0",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
+ "spl-associated-token-account",
+ "spl-token-2022",
+ "spl-token-confidential-transfer-proof-extraction",
  "utils",
 ]
 
@@ -2904,54 +2437,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,19 +2445,19 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -3002,12 +2487,6 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num"
@@ -3114,48 +2593,34 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3212,13 +2677,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.4.1+3.4.0"
+name = "openssl-probe"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
-dependencies = [
- "cc",
-]
+checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "openssl-sys"
@@ -3228,40 +2690,17 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.17.0"
+name = "pairing"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.8",
+ "group",
 ]
 
 [[package]]
@@ -3294,27 +2733,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-dependencies = [
- "crypto-mac",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.7",
+ "digest",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -3337,19 +2771,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "percentage"
@@ -3442,58 +2867,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "pretty-hex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3502,30 +2879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -3579,17 +2932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qualifier_attr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "quanta"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3606,38 +2948,42 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.22",
- "socket2",
- "thiserror 2.0.11",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "fastbloom",
+ "getrandom 0.3.1",
+ "lru-slab",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.0",
- "rustls 0.23.22",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3652,7 +2998,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3667,17 +3013,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.7.3"
+name = "radium"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3691,13 +3030,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.2.2"
+name = "rand"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3711,12 +3050,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.5.1"
+name = "rand_chacha"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
- "getrandom 0.1.16",
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3729,19 +3069,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.2.0"
+name = "rand_core"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "rand_core 0.5.1",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
+name = "rand_xorshift"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -3757,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -3767,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3788,7 +3128,7 @@ dependencies = [
  "setup_participants",
  "setup_token_account",
  "solana-sdk",
- "solana-zk-sdk",
+ "spl-token-2022",
  "tokio",
  "transfer",
  "utils",
@@ -3850,7 +3190,6 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64 0.21.7",
  "bytes",
  "encoding_rs",
@@ -3860,18 +3199,15 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -3880,74 +3216,73 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
- "tokio-util 0.7.13",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper 1.8.1",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.2.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 0.2.12",
- "reqwest 0.11.27",
+ "http 1.2.0",
+ "reqwest 0.12.28",
  "serde",
- "task-local-extensions",
  "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -3956,7 +3291,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -3977,13 +3312,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4047,42 +3382,29 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
- "rustls-pemfile 2.2.0",
+ "openssl-probe 0.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -4105,32 +3427,33 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.4.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c7dc240fec5517e6c4eab3310438636cfe6391dfc345ba013109909a90d136"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.22",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.8",
- "security-framework",
+ "rustls-webpki",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4141,19 +3464,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4197,22 +3510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4233,18 +3530,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
- "num-bigint 0.4.6",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4252,26 +3561,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
-
-[[package]]
-name = "seqlock"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c67b6f14ecc5b86c66fa63d76b5092352678545a8a3cdae80aef5128371910"
-dependencies = [
- "parking_lot",
-]
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4284,10 +3594,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4296,14 +3615,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4347,7 +3667,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -4359,7 +3679,8 @@ name = "setup_mint"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "spl-token-2022 7.0.0",
+ "solana-system-interface",
+ "spl-token-2022",
  "spl-token-client",
  "utils",
 ]
@@ -4369,7 +3690,8 @@ name = "setup_mint_confidential"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "spl-token-2022 7.0.0",
+ "solana-system-interface",
+ "spl-token-2022",
  "spl-token-client",
  "utils",
 ]
@@ -4379,6 +3701,7 @@ name = "setup_participants"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
+ "solana-system-interface",
  "tokio",
  "utils",
 ]
@@ -4388,9 +3711,9 @@ name = "setup_token_account"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "spl-associated-token-account 6.0.0",
- "spl-token-2022 7.0.0",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
+ "spl-associated-token-account",
+ "spl-token-2022",
+ "spl-token-confidential-transfer-proof-extraction",
  "tokio",
  "utils",
 ]
@@ -4403,20 +3726,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -4427,7 +3737,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4436,17 +3746,8 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -4472,17 +3773,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -4494,7 +3789,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -4505,14 +3800,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
+name = "siphasher"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -4525,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -4540,313 +3831,248 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-account"
-version = "2.1.11"
+name = "socket2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2af97266ee346ef1cd1649ba462d08bd3d254e50c06c45d3e70a21871a1da6a"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "solana-account"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e0ac2a81ae17e1b3570deb50242ab4cfde50b848b898f57288b6271cc7b71f"
 dependencies = [
  "bincode",
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-instruction",
- "solana-program",
+ "solana-account-info",
+ "solana-clock",
+ "solana-instruction-error",
+ "solana-pubkey 4.0.0",
+ "solana-sdk-ids",
+ "solana-sysvar",
 ]
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717a67d421f9ba91a7b845af1d5b0039fcb44b86f4b294b28ae447a0f2bf48c8"
+checksum = "2743ab6d07e8261a2066d9f118a566a9c4c2143629a3c3d0a7dc58c3d37b659f"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
  "bincode",
  "bs58 0.5.1",
  "bv",
- "lazy_static",
  "serde",
- "serde_derive",
  "serde_json",
+ "solana-account",
  "solana-account-decoder-client-types",
- "solana-config-program",
- "solana-sdk",
- "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
- "spl-token-group-interface 0.3.0",
- "spl-token-metadata-interface 0.4.0",
- "thiserror 1.0.69",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-config-interface",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-instruction",
+ "solana-loader-v3-interface",
+ "solana-nonce",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stake-interface",
+ "solana-sysvar",
+ "solana-vote-interface",
+ "spl-generic-token",
+ "spl-token-2022-interface",
+ "spl-token-group-interface",
+ "spl-token-interface",
+ "spl-token-metadata-interface",
+ "thiserror 2.0.17",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42008241f82751639daee861f1ecaf9c3342d3aa6ce96c063290379a5f9f7c0"
+checksum = "903d72faba9acbb483b35e00d5c84e4245367336410553fc4d1f216219283724"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
  "serde",
- "serde_derive",
  "serde_json",
  "solana-account",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-info"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed2417317f26f0941dd8e552ac1f9768eb2aa3b7f16ec992a6833f058295bea"
+checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
 dependencies = [
  "bincode",
- "serde",
+ "serde_core",
+ "solana-address 2.0.0",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey",
 ]
 
 [[package]]
-name = "solana-accounts-db"
-version = "2.1.11"
+name = "solana-address"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c774151c02b7dd2e92985ccd23c16ab2c241a16c863fdfa84fc2afb6dbdc61"
+checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "ahash",
- "bincode",
- "blake3",
- "bv",
+ "solana-address 2.0.0",
+]
+
+[[package]]
+name = "solana-address"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37320fd2945c5d654b2c6210624a52d66c3f1f73b653ed211ab91a703b35bdd"
+dependencies = [
+ "borsh",
  "bytemuck",
  "bytemuck_derive",
- "bzip2",
- "crossbeam-channel",
- "dashmap",
- "index_list",
- "indexmap 2.7.1",
- "itertools 0.12.1",
- "lazy_static",
- "log",
- "lz4",
- "memmap2",
- "modular-bitfield",
- "num_cpus",
- "num_enum",
+ "curve25519-dalek",
+ "five8 1.0.0",
+ "five8_const",
  "rand 0.8.5",
- "rayon",
- "seqlock",
  "serde",
  "serde_derive",
- "smallvec",
- "solana-bucket-map",
- "solana-inline-spl",
- "solana-lattice-hash",
- "solana-measure",
- "solana-metrics",
- "solana-nohash-hasher",
- "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-svm-transaction",
- "static_assertions",
- "tar",
- "tempfile",
- "thiserror 1.0.69",
+ "solana-atomic-u64",
+ "solana-define-syscall 4.0.1",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sha256-hasher",
 ]
 
 [[package]]
-name = "solana-address-lookup-table-program"
-version = "2.1.11"
+name = "solana-address-lookup-table-interface"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bbb4763b5ed9a66cabdb799d3fa4a5823988ec0b6812b09131510f5a5e491b"
+checksum = "5e8df0b083c10ce32490410f3795016b1b5d9b4d094658c0a5e496753645b7cd"
 dependencies = [
  "bincode",
  "bytemuck",
- "log",
- "num-derive",
- "num-traits",
- "solana-feature-set",
- "solana-log-collector",
- "solana-program",
- "solana-program-runtime",
- "solana-sdk",
- "thiserror 1.0.69",
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-pubkey 4.0.0",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
 ]
 
 [[package]]
 name = "solana-atomic-u64"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0cd0453d46a62ed36ce234be9153a3c4d433711f1cec6943345d1637d6a0908"
+checksum = "a933ff1e50aff72d02173cfcd7511bd8540b027ee720b75f353f594f834216d0"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
-name = "solana-banks-client"
-version = "2.1.11"
+name = "solana-big-mod-exp"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ac58ba6608947de344febfbfa3e6b6967602624af5f5e6ff193b67bce60c25"
+checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
 dependencies = [
- "borsh 1.5.5",
- "futures",
- "solana-banks-interface",
- "solana-program",
- "solana-sdk",
- "tarpc",
- "thiserror 1.0.69",
- "tokio",
- "tokio-serde",
-]
-
-[[package]]
-name = "solana-banks-interface"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af6759cbf948431646bfe73af53e115ebc4439f8a4a40120a6b04a315a5563c"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk",
- "tarpc",
-]
-
-[[package]]
-name = "solana-banks-server"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81b05f589b95dd7ecd3909b34e0435fd782ce413afbce68af58ecd77c79b5bb"
-dependencies = [
- "bincode",
- "crossbeam-channel",
- "futures",
- "solana-banks-interface",
- "solana-client",
- "solana-feature-set",
- "solana-runtime",
- "solana-sdk",
- "solana-send-transaction-service",
- "solana-svm",
- "tarpc",
- "tokio",
- "tokio-serde",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "solana-define-syscall 3.0.0",
 ]
 
 [[package]]
 name = "solana-bincode"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97957d987dc85bbfa90cb7e919ee0b071206affc0209e7221d7ea4844e7be31"
+checksum = "278a1a5bad62cd9da89ac8d4b7ec444e83caa8ae96aa656dfc27684b28d49a5d"
 dependencies = [
  "bincode",
- "serde",
- "solana-instruction",
+ "serde_core",
+ "solana-instruction-error",
 ]
 
 [[package]]
-name = "solana-bn254"
-version = "2.1.11"
+name = "solana-blake3-hasher"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957ce0d8b021f78f7b3c99d82b21a8dae617cf016377647c4d43a6e3141e8f2f"
+checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "bytemuck",
- "solana-program",
- "thiserror 1.0.69",
+ "blake3",
+ "solana-define-syscall 4.0.1",
+ "solana-hash 4.0.1",
+]
+
+[[package]]
+name = "solana-bls-signatures"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c75573697bbb148afa8209aa3ce228ca0754584c9a8a91e818db0f706ae4fb"
+dependencies = [
+ "base64 0.22.1",
+ "blst",
+ "blstrs",
+ "cfg_eval",
+ "ff",
+ "group",
+ "pairing",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-borsh"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99affe31b10c1cd4a6438d307b92c1b17c89c974aebf2c2aa15cd790d0ba672b"
+checksum = "dc402b16657abbfa9991cd5cbfac5a11d809f7e7d28d3bb291baeb088b39060e"
 dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.5",
-]
-
-[[package]]
-name = "solana-bpf-loader-program"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29eca845657e02a138b4ed7ea8520c59a37f8b2d6eb92059f68b8c77440272d"
-dependencies = [
- "bincode",
- "byteorder",
- "libsecp256k1",
- "log",
- "scopeguard",
- "solana-bn254",
- "solana-compute-budget",
- "solana-curve25519",
- "solana-feature-set",
- "solana-log-collector",
- "solana-measure",
- "solana-poseidon",
- "solana-program-memory",
- "solana-program-runtime",
- "solana-sdk",
- "solana-timings",
- "solana-type-overrides",
- "solana_rbpf",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-bucket-map"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a840139873975c05cfd27aabf568b86173e9f351f56e1dbb705a531d5acdb3f7"
-dependencies = [
- "bv",
- "bytemuck",
- "bytemuck_derive",
- "log",
- "memmap2",
- "modular-bitfield",
- "num_enum",
- "rand 0.8.5",
- "solana-measure",
- "solana-sdk",
- "tempfile",
-]
-
-[[package]]
-name = "solana-builtins-default-costs"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121fcdb8b5323c8a8ffab77e02b001c178f333ffc3bc990abee181fa8a19bc6c"
-dependencies = [
- "ahash",
- "lazy_static",
- "log",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-loader-v4-program",
- "solana-sdk",
- "solana-stake-program",
- "solana-system-program",
- "solana-vote-program",
+ "borsh",
 ]
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7cfc66807d0aee9130a906d73d0b7d59754c0edcf1f1a1486eb334abb56835"
+checksum = "e02ceca9a77472dc6ad4e0d54ca83501b724985c16768c9d8b26e5f358111483"
 dependencies = [
  "chrono",
  "clap",
  "rpassword",
+ "solana-bls-signatures",
+ "solana-clock",
+ "solana-cluster-type",
+ "solana-commitment-config",
  "solana-derivation-path",
+ "solana-hash 3.1.0",
+ "solana-keypair",
+ "solana-message",
+ "solana-native-token",
+ "solana-presigner",
+ "solana-pubkey 3.0.0",
  "solana-remote-wallet",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "thiserror 2.0.17",
  "tiny-bip39",
  "uriparse",
  "url",
@@ -4854,213 +4080,256 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771b25c9091dddfa3cb7cb0cce62eb4b24840db61c29ee6c3541f1519e1c7953"
+checksum = "f9f8529cdbcb608841490d2f66a66617e991efcb8acbfaa038fd154a6685348f"
 dependencies = [
  "dirs-next",
- "lazy_static",
  "serde",
- "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk",
+ "solana-commitment-config",
  "url",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f104a84a5e92dc34fb972e9e3fa87e1414cc26c29793407e75bab2a87285ee"
+checksum = "b7eaf400ee406e0361b6b86cf680b570cc120c1d646bd6c135a6f75d291a1a2b"
 dependencies = [
  "Inflector",
+ "agave-reserved-account-keys",
  "base64 0.22.1",
  "chrono",
  "clap",
- "console",
+ "console 0.16.2",
  "humantime",
  "indicatif",
  "pretty-hex",
  "semver",
  "serde",
  "serde_json",
+ "solana-account",
  "solana-account-decoder",
+ "solana-bincode",
  "solana-clap-utils",
  "solana-cli-config",
+ "solana-clock",
+ "solana-epoch-info",
+ "solana-hash 3.1.0",
+ "solana-message",
+ "solana-packet",
+ "solana-pubkey 3.0.0",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-stake-interface",
+ "solana-system-interface",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status",
+ "solana-transaction-status-client-types",
  "solana-vote-program",
- "spl-memo 5.0.0",
+ "spl-memo-interface",
 ]
 
 [[package]]
 name = "solana-client"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433292dc183886b1f36ee87e971477556226df2f566fc5a19585a0d740aa8b0"
+checksum = "6ee8a02f1f8646d456d75a0ca3aa3c8aee3e06b1f22a5b25dfcbdc8d87855aa5"
 dependencies = [
  "async-trait",
  "bincode",
  "dashmap",
  "futures",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "indicatif",
  "log",
  "quinn",
  "rayon",
+ "solana-account",
+ "solana-client-traits",
+ "solana-commitment-config",
  "solana-connection-cache",
+ "solana-epoch-info",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keypair",
  "solana-measure",
+ "solana-message",
+ "solana-net-utils",
+ "solana-pubkey 3.0.0",
  "solana-pubsub-client",
  "solana-quic-client",
+ "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-rpc-client-nonce-utils",
- "solana-sdk",
+ "solana-signature",
+ "solana-signer",
  "solana-streamer",
- "solana-thin-client",
+ "solana-time-utils",
  "solana-tpu-client",
+ "solana-transaction",
+ "solana-transaction-error",
+ "solana-transaction-status-client-types",
  "solana-udp-client",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "solana-client-traits"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08618ed587e128105510c54ae3e456b9a06d674d8640db75afe66dad65cb4e02"
+dependencies = [
+ "solana-account",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-message",
+ "solana-pubkey 3.0.0",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
+ "solana-transaction-error",
 ]
 
 [[package]]
 name = "solana-clock"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97864f28abd43d03e7ca7242059e340bb6e637e0ce99fd66f6420c43fa359898"
+checksum = "fb62e9381182459a4520b5fe7fb22d423cae736239a6427fc398a88743d0ed59"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-compute-budget"
-version = "2.1.11"
+name = "solana-cluster-type"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f92a2ba8c5ed92fc805f8a92a3bfbbaca05da80d87f180aea4e9f28b9e0fa22"
+checksum = "eb7692fa6bf10a1a86b450c4775526f56d7e0e2116a53313f2533b5694abea64"
 dependencies = [
- "solana-sdk",
+ "solana-hash 3.1.0",
 ]
 
 [[package]]
-name = "solana-compute-budget-program"
-version = "2.1.11"
+name = "solana-commitment-config"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d808b196db3d847d05bb8865c64a97c1848b7267850a0a936abdd81bf98ad6"
+checksum = "2e41a3917076a8b5375809078ae3a6fb76a53e364b596ef8c4265e7f410876f3"
 dependencies = [
- "solana-program-runtime",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-config-program"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a78fbed4792e4cd029a0dd95d14ec42ea602fd7247b40e8fbc4c96b3404da1"
-dependencies = [
- "bincode",
- "chrono",
  "serde",
  "serde_derive",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
+]
+
+[[package]]
+name = "solana-compute-budget-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8292c436b269ad23cecc8b24f7da3ab07ca111661e25e00ce0e1d22771951ab9"
+dependencies = [
+ "solana-instruction",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-config-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e401ae56aed512821cc7a0adaa412ff97fecd2dff4602be7b1330d2daec0c4"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
  "solana-short-vec",
+ "solana-system-interface",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aa1f4cb4c3829357189e6a88624205016b0710f11509f84f772c87c4887159"
+checksum = "97904fc33d6ac88fe4012f631bd0a7674e5cdda22934930844e99618a140efdc"
 dependencies = [
  "async-trait",
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "log",
  "rand 0.8.5",
  "rayon",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-time-utils",
+ "solana-transaction-error",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
-name = "solana-cost-model"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cbca9a3f3034d25efe7bfc28806e601818e2ce2edb3e633bace413406ab90b"
-dependencies = [
- "ahash",
- "lazy_static",
- "log",
- "solana-builtins-default-costs",
- "solana-compute-budget",
- "solana-feature-set",
- "solana-metrics",
- "solana-runtime-transaction",
- "solana-sdk",
- "solana-svm-transaction",
- "solana-vote-program",
-]
-
-[[package]]
 name = "solana-cpi"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54c3b096dc77222b9c19ffe9cf6c1c32bd1e9882ceb955d213be4315bbe3b95"
+checksum = "4dea26709d867aada85d0d3617db0944215c8bb28d3745b912de7db13a23280c"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall",
+ "solana-define-syscall 4.0.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 4.0.0",
  "solana-stable-layout",
 ]
 
 [[package]]
 name = "solana-curve25519"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2ed697e82c44b0833550501e3fab428c07cc2865c788307fad4c98a64d27d0"
+checksum = "e7012a457fa158f4b0e7160add8d3882536177a2e4942be5c993f7bff65edbec"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek 4.1.3",
- "solana-program",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-decode-error"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c92852914fe0cfec234576a30b1de4b11516dd729226d5de04e4c67d80447a7"
-dependencies = [
- "num-traits",
+ "curve25519-dalek",
+ "solana-define-syscall 3.0.0",
+ "subtle",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-define-syscall"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44015e77f6f321bf526f7d026b08d8f34b57b1ea6e46038fd13e59f43a53a475"
+checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
+
+[[package]]
+name = "solana-define-syscall"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-derivation-path"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cd4b95383d8926cc22d4a33417aa2e38897475f259cff4eb319c8cf0f7ac02"
+checksum = "ff71743072690fdbdfcdc37700ae1cb77485aaad49019473a81aee099b1e0b8c"
 dependencies = [
  "derivation-path",
  "qstring",
@@ -5068,46 +4337,102 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-epoch-schedule"
-version = "2.1.11"
+name = "solana-epoch-info"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3409f250234ec4bbd999de3eac727ca21dfbfd39a831906f6ec112a66d2e1a2"
+checksum = "e093c84f6ece620a6b10cd036574b0cd51944231ab32d81f80f76d54aba833e6"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "solana-epoch-rewards"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b319a4ed70390af911090c020571f0ff1f4ec432522d05ab89f5c08080381995"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash 3.1.0",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-feature-set"
-version = "2.1.11"
+name = "solana-epoch-rewards-hasher"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ddda14ac5f2da82da4df043eabca2f2c00ac0d59f10295b8c8c3404fcc5f67"
+checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
 dependencies = [
- "lazy_static",
- "solana-clock",
- "solana-epoch-schedule",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
+ "siphasher 0.3.11",
+ "solana-address 2.0.0",
+ "solana-hash 4.0.1",
 ]
 
 [[package]]
-name = "solana-fee"
-version = "2.1.11"
+name = "solana-epoch-schedule"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3833997f63d17b74444d1445261737051181074e22899470dc256b143334034"
+checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
 dependencies = [
- "solana-sdk",
- "solana-svm-transaction",
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-stake"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc6693d0ea833b880514b9b88d95afb80b42762dca98b0712465d1fcbbcb89e"
+dependencies = [
+ "solana-define-syscall 3.0.0",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-example-mocks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978855d164845c1b0235d4b4d101cadc55373fffaf0b5b6cfa2194d25b2ed658"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-message",
+ "solana-nonce",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "solana-feature-gate-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347ab62e6d47a82e340c865133795b394feea7c2b2771d293f57691c6544c3f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
 ]
 
 [[package]]
 name = "solana-fee-calculator"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8db8c4be5e012215ed1e3394cd3c188e217dd4f0c821045e5d2c1262aac8b4e"
+checksum = "2a73cc03ca4bed871ca174558108835f8323e85917bb38b9c81c7af2ab853efe"
 dependencies = [
  "log",
  "serde",
@@ -5115,188 +4440,287 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-hash"
-version = "2.1.11"
+name = "solana-fee-structure"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25925816be2f57992c4c5af7dff31713bc95696c2fbc4bca911e290ba2f330"
+checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
 dependencies = [
- "borsh 1.5.5",
- "bs58 0.5.1",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-hard-forks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abacc4b66ce471f135f48f22facf75cbbb0f8a252fbe2c1e0aa59d5b203f519"
+
+[[package]]
+name = "solana-hash"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
+dependencies = [
+ "solana-hash 4.0.1",
+]
+
+[[package]]
+name = "solana-hash"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5d48a6ee7b91fc7b998944ab026ed7b3e2fc8ee3bc58452644a86c2648152f"
+dependencies = [
+ "borsh",
  "bytemuck",
  "bytemuck_derive",
- "js-sys",
+ "five8 1.0.0",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-inflation"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91a53086a0f0cc093ffce9e5be4399785f05a0d49f0ff2cd6d5f3f4d593e2e9"
+checksum = "e92f37a14e7c660628752833250dd3dcd8e95309876aee751d7f8769a27947c6"
 dependencies = [
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "solana-inline-spl"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4fa02c553c48a6e189960b5bd3aa854b29c888bd5db4c1ad4bb6a0cc068c78"
-dependencies = [
- "bytemuck",
- "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-instruction"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab8c46b6f76857222ee1adeb7031b8eb0eb5134920614e9fd1bd710052b96a9"
+checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
 dependencies = [
  "bincode",
- "borsh 1.5.5",
- "getrandom 0.2.15",
- "js-sys",
+ "borsh",
+ "serde",
+ "serde_derive",
+ "solana-define-syscall 4.0.1",
+ "solana-instruction-error",
+ "solana-pubkey 4.0.0",
+]
+
+[[package]]
+name = "solana-instruction-error"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04259e03c05faf38a8c24217b5cfe4c90572ae6184ab49cddb1584fdd756d3f"
+dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-define-syscall",
- "solana-pubkey",
- "wasm-bindgen",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-instructions-sysvar"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
+dependencies = [
+ "bitflags 2.8.0",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-keccak-hasher"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
+dependencies = [
+ "sha3",
+ "solana-define-syscall 4.0.1",
+ "solana-hash 4.0.1",
+]
+
+[[package]]
+name = "solana-keypair"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8be597c9e231b0cab2928ce3bc3e4ee77d9c0ad92977b9d901f3879f25a7a"
+dependencies = [
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "five8 1.0.0",
+ "rand 0.8.5",
+ "solana-address 2.0.0",
+ "solana-derivation-path",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
 ]
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633f272467f3e1a28dfcfb1a7df55129752524a18938a84fd67086e205f0bd88"
+checksum = "dcda154ec827f5fc1e4da0af3417951b7e9b8157540f81f936c4a8b1156134d0"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-lattice-hash"
-version = "2.1.11"
+name = "solana-loader-v2-interface"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de355156f6d83f492ee424cb2fdd22a0fe01b0f5a5b7566281668bc26edbcd6"
+checksum = "1e4a6f0ad4fd9c30679bfee2ce3ea6a449cac38049f210480b751f65676dfe82"
 dependencies = [
- "base64 0.22.1",
- "blake3",
- "bs58 0.5.1",
- "bytemuck",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
 ]
 
 [[package]]
-name = "solana-loader-v4-program"
-version = "2.1.11"
+name = "solana-loader-v3-interface"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d44ec109bf98f1e15335ad9fce8ea4f8c8103b855a4945bdbcea861b0cac613"
+checksum = "dee44c9b1328c5c712c68966fb8de07b47f3e7bac006e74ddd1bb053d3e46e5d"
 dependencies = [
- "log",
- "solana-bpf-loader-program",
- "solana-compute-budget",
- "solana-log-collector",
- "solana-measure",
- "solana-program-runtime",
- "solana-sdk",
- "solana-type-overrides",
- "solana_rbpf",
-]
-
-[[package]]
-name = "solana-log-collector"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034627f9849eeafcbfa24f0e4ad0da50eb68422ceab5c605b7d87755af77b201"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "solana-logger"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef1468f78c6f891ac2e3ce6e81bd0c47cff18598fb87618ab2e3d39da4bb69f"
-dependencies = [
- "env_logger",
- "lazy_static",
- "log",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-system-interface",
 ]
 
 [[package]]
 name = "solana-measure"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fa953c2b49a131492b5927e714ab60b7b927610c7ed3355b9ad28909622b5e"
+checksum = "ef687aac555fa8ab56f1fff63be6902c484784344ce195653bd840a3d19462be"
+
+[[package]]
+name = "solana-message"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85666605c9fd727f865ed381665db0a8fc29f984a030ecc1e40f43bfb2541623"
+dependencies = [
+ "bincode",
+ "blake3",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-address 1.1.0",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-transaction-error",
+]
 
 [[package]]
 name = "solana-metrics"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce8eeecdde1cfed801d0d8683856e0e0cc731119894a7ae77a966915cf84964"
+checksum = "0f3595ded6be33832d82c75d3bcae1018f48635b3ec47578d275c807ab1cb565"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
- "lazy_static",
  "log",
- "reqwest 0.11.27",
- "solana-sdk",
- "thiserror 1.0.69",
+ "reqwest 0.12.28",
+ "solana-cluster-type",
+ "solana-sha256-hasher",
+ "solana-time-utils",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-msg"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80dde3316c6ee6e8d57bf105139ec93f8c32a42fe3ec42a3cda2ca9efb72c0e6"
+checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
 dependencies = [
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
 ]
 
 [[package]]
 name = "solana-native-token"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0721f46122a2f1837f571d5a6c1478c962ebefd6d65d02694b3a267b58dbf2"
+checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404052690fb907fdda741f662610ac26c785cdff2154204a109b14d3e2f4b6bd"
+checksum = "54820b244f1bc56514cf02232453046ea537c9e590478962e976a62162f17915"
 dependencies = [
+ "anyhow",
  "bincode",
- "crossbeam-channel",
+ "bytes",
+ "cfg-if",
+ "dashmap",
+ "itertools 0.12.1",
  "log",
  "nix",
  "rand 0.8.5",
  "serde",
- "serde_derive",
- "socket2",
- "solana-sdk",
+ "socket2 0.6.1",
+ "solana-serde",
+ "solana-svm-type-overrides",
  "tokio",
  "url",
 ]
 
 [[package]]
-name = "solana-nohash-hasher"
-version = "0.2.1"
+name = "solana-nonce"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
+checksum = "abbdc6c8caf1c08db9f36a50967539d0f72b9f1d4aea04fec5430f532e5afadc"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-fee-calculator",
+ "solana-hash 3.1.0",
+ "solana-pubkey 3.0.0",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-offchain-message"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e2a1141a673f72a05cf406b99e4b2b8a457792b7c01afa07b3f00d4e2de393"
+dependencies = [
+ "num_enum",
+ "solana-hash 3.1.0",
+ "solana-packet",
+ "solana-pubkey 3.0.0",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "solana-signature",
+ "solana-signer",
+]
 
 [[package]]
 name = "solana-packet"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fcc5cf0ef0ac6a62dd09fae772672c2d6865ee1d1ba5fbfbcc94b2c37b2be8"
+checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
 dependencies = [
  "bincode",
  "bitflags 2.8.0",
@@ -5308,100 +4732,81 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed01176ddc5ade70e0782b3eeea0f5e98f183dc5b225e4e051834e63a288c0"
+checksum = "32ce50c6e8de8616805c3e7b327289288bdb3385b309ec197ddd5fa05ba16780"
 dependencies = [
  "ahash",
  "bincode",
  "bv",
+ "bytes",
  "caps",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "dlopen2",
  "fnv",
- "lazy_static",
  "libc",
  "log",
  "nix",
  "rand 0.8.5",
  "rayon",
  "serde",
+ "solana-hash 3.1.0",
+ "solana-message",
  "solana-metrics",
+ "solana-packet",
+ "solana-pubkey 3.0.0",
  "solana-rayon-threadlimit",
- "solana-sdk",
+ "solana-sdk-ids",
  "solana-short-vec",
- "solana-vote-program",
-]
-
-[[package]]
-name = "solana-poseidon"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133321939f27f2e0eaeb556530757466b9e90b7acea06a216ace10f7e95ca0d9"
-dependencies = [
- "ark-bn254",
- "light-poseidon",
- "solana-define-syscall",
- "thiserror 1.0.69",
+ "solana-signature",
+ "solana-time-utils",
+ "solana-transaction-context",
 ]
 
 [[package]]
 name = "solana-precompile-error"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54310052930124b78392b03d802aa465afe6fded96d97f2e6ca6b1dead85d8d9"
+checksum = "cafcd950de74c6c39d55dc8ca108bbb007799842ab370ef26cf45a34453c31e1"
 dependencies = [
  "num-traits",
- "solana-decode-error",
+]
+
+[[package]]
+name = "solana-presigner"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f704eaf825be3180832445b9e4983b875340696e8e7239bf2d535b0f86c14a2"
+dependencies = [
+ "solana-pubkey 3.0.0",
+ "solana-signature",
+ "solana-signer",
 ]
 
 [[package]]
 name = "solana-program"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12511916a9658664921ca12dd6214910de655ac9955159c1e9871bd516936cac"
+checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
 dependencies = [
- "base64 0.22.1",
- "bincode",
- "bitflags 2.8.0",
- "blake3",
- "borsh 0.10.4",
- "borsh 1.5.5",
- "bs58 0.5.1",
- "bv",
- "bytemuck",
- "bytemuck_derive",
- "console_error_panic_hook",
- "console_log",
- "curve25519-dalek 4.1.3",
- "five8_const",
- "getrandom 0.2.15",
- "js-sys",
- "lazy_static",
- "log",
  "memoffset",
- "num-bigint 0.4.6",
- "num-derive",
- "num-traits",
- "parking_lot",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "sha2 0.10.8",
- "sha3",
  "solana-account-info",
- "solana-atomic-u64",
- "solana-bincode",
+ "solana-big-mod-exp",
+ "solana-blake3-hasher",
  "solana-borsh",
  "solana-clock",
  "solana-cpi",
- "solana-decode-error",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
+ "solana-epoch-rewards",
  "solana-epoch-schedule",
+ "solana-epoch-stake",
+ "solana-example-mocks",
  "solana-fee-calculator",
- "solana-hash",
+ "solana-hash 3.1.0",
  "solana-instruction",
+ "solana-instruction-error",
+ "solana-instructions-sysvar",
+ "solana-keccak-hasher",
  "solana-last-restart-slot",
  "solana-msg",
  "solana-native-token",
@@ -5410,10 +4815,9 @@ dependencies = [
  "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-rent",
- "solana-sanitize",
- "solana-sdk-macro",
+ "solana-sdk-ids",
  "solana-secp256k1-recover",
  "solana-serde-varint",
  "solana-serialize-utils",
@@ -5422,176 +4826,140 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
+ "solana-sysvar",
  "solana-sysvar-id",
- "solana-transaction-error",
- "thiserror 1.0.69",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "2.1.11"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3422fa98d2ac5b20df9c9feb9f638e1170341b3c4259c26cd91a6a7098f6830"
+checksum = "84c9b0a1ff494e05f503a08b3d51150b73aa639544631e510279d6375f290997"
 dependencies = [
  "solana-account-info",
- "solana-msg",
+ "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 4.0.0",
 ]
 
 [[package]]
 name = "solana-program-error"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2ea6d8e88767586e6d547e5afb00cda08cee79c986443b2d47236aac50a755"
+checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
 dependencies = [
- "borsh 1.5.5",
- "num-traits",
+ "borsh",
  "serde",
  "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-program-memory"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716e1c9cbd3c5e9d9147ffb7e74815cfb34ff7a3196127da64aa8d1866beab52"
+checksum = "4068648649653c2c50546e9a7fb761791b5ab0cda054c771bb5808d3a4b9eb52"
 dependencies = [
- "num-traits",
- "solana-define-syscall",
+ "solana-define-syscall 4.0.1",
 ]
 
 [[package]]
 name = "solana-program-option"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c8ffad2c86e5de375ae5f0a46f64eb5897a63c514e958e908c1a98059c57d4"
+checksum = "8e7b4ddb464f274deb4a497712664c3b612e3f5f82471d4e47710fc4ab1c3095"
 
 [[package]]
 name = "solana-program-pack"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c185f9170ac85a93d5caaaaf5fe7bf0d49febdb329506bd7ea13716e4eb0189"
+checksum = "c169359de21f6034a63ebf96d6b380980307df17a8d371344ff04a883ec4e9d0"
 dependencies = [
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cf60b4b2d8d70b082d03973b8e646ca1c65351eb12ab33427c2df40cd178cf"
+checksum = "1da9aa0062feef8162662725dbadc2f9aed390e64ab3536176085cced4b7050b"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "enum-iterator",
  "itertools 0.12.1",
- "libc",
  "log",
- "num-derive",
- "num-traits",
  "percentage",
  "rand 0.8.5",
  "serde",
- "solana-compute-budget",
- "solana-feature-set",
- "solana-log-collector",
- "solana-measure",
- "solana-metrics",
- "solana-sdk",
- "solana-timings",
- "solana-type-overrides",
- "solana-vote",
- "solana_rbpf",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-program-test"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e05e1a5aba5d228d8a4fe9eeab59ef093b901d229156a6fbc85fdcb929dbc3"
-dependencies = [
- "assert_matches",
- "async-trait",
- "base64 0.22.1",
- "bincode",
- "chrono-humanize",
- "crossbeam-channel",
- "log",
- "serde",
- "solana-accounts-db",
- "solana-banks-client",
- "solana-banks-interface",
- "solana-banks-server",
- "solana-bpf-loader-program",
- "solana-compute-budget",
- "solana-feature-set",
- "solana-inline-spl",
+ "solana-account",
+ "solana-account-info",
+ "solana-clock",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
  "solana-instruction",
- "solana-log-collector",
- "solana-logger",
- "solana-program-runtime",
- "solana-runtime",
- "solana-sdk",
- "solana-svm",
- "solana-timings",
- "solana-vote-program",
- "solana_rbpf",
- "thiserror 1.0.69",
- "tokio",
+ "solana-last-restart-slot",
+ "solana-loader-v3-interface",
+ "solana-program-entrypoint",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-stable-layout",
+ "solana-stake-interface",
+ "solana-svm-callback",
+ "solana-svm-feature-set",
+ "solana-svm-log-collector",
+ "solana-svm-measure",
+ "solana-svm-timings",
+ "solana-svm-transaction",
+ "solana-svm-type-overrides",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-transaction-context",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-pubkey"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb80787769457f022a39a55cf439d1996aeecc2364c99483c97318d80f15436"
+checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
 dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.5",
- "bs58 0.5.1",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek 4.1.3",
- "five8_const",
- "getrandom 0.2.15",
- "js-sys",
- "num-traits",
  "rand 0.8.5",
- "serde",
- "serde_derive",
- "solana-atomic-u64",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-sanitize",
- "solana-sha256-hasher",
- "wasm-bindgen",
+ "solana-address 1.1.0",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f7104d456b58e1418c21a8581e89810278d1190f70f27ece7fc0b2c9282a57"
+dependencies = [
+ "solana-address 2.0.0",
 ]
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d5e1c9d387f98d46a675f418f29b73a5555ceddc2800faa38ce2f87feba3b2"
+checksum = "2b3b7936218ede5b8a4c87182e5ddea5185725215b2a2866246e8152e52f7fcf"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
+ "http 0.2.12",
  "log",
- "reqwest 0.11.27",
  "semver",
  "serde",
- "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-rpc-client-api",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-pubkey 3.0.0",
+ "solana-rpc-client-types",
+ "solana-signature",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -5601,47 +4969,60 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8579061d3a98f3b6b45f675da8b4fdcf435109ef6c6269b95ee0f33a52a5ac4d"
+checksum = "f4adf1b06dce39d8c0bed00eba133128b3b96c8005313245bb6863d4eefd2022"
 dependencies = [
  "async-lock",
  "async-trait",
  "futures",
  "itertools 0.12.1",
- "lazy_static",
  "log",
  "quinn",
  "quinn-proto",
- "rustls 0.23.22",
+ "rustls",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
+ "solana-pubkey 3.0.0",
+ "solana-quic-definitions",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-signer",
  "solana-streamer",
- "thiserror 1.0.69",
+ "solana-tls-utils",
+ "solana-transaction-error",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
-name = "solana-rayon-threadlimit"
-version = "2.1.11"
+name = "solana-quic-definitions"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cac659c899faffd06d57164fbdf142d7395e147843031ecd0ec48ee11be3b06"
+checksum = "15319accf7d3afd845817aeffa6edd8cc185f135cefbc6b985df29cfd8c09609"
 dependencies = [
- "lazy_static",
+ "solana-keypair",
+]
+
+[[package]]
+name = "solana-rayon-threadlimit"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c6a12644a32196de6e7dfdd5ad66183f952fe259ad4f166260838369f14a8e"
+dependencies = [
+ "log",
  "num_cpus",
 ]
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531d38fa26935c234d9b111362377a886f3662dd5c76477fa05c48144625f1e4"
+checksum = "4e068304b987f1c1db02f11e1fad01e1d85bca8ecbc4f61db88a268f6927fc74"
 dependencies = [
- "console",
+ "console 0.16.2",
  "dialoguer",
  "log",
  "num-derive",
@@ -5650,265 +5031,217 @@ dependencies = [
  "qstring",
  "semver",
  "solana-derivation-path",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-offchain-message",
+ "solana-pubkey 3.0.0",
+ "solana-signature",
+ "solana-signer",
+ "thiserror 2.0.17",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rent"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b4cd58602eb0c2250cd83a8cc8287ca6271b99af95d2a33250e6592c04e286"
+checksum = "e860d5499a705369778647e97d760f7670adfb6fc8419dd3d568deccd46d5487"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-rpc-client"
-version = "2.1.11"
+name = "solana-reward-info"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3102d6dfbadc375f22f7413effafcf2d7d2cb3e8cdf64f366dacd7c5cbae27cb"
+checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-rpc-client"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403ce2edf55df72d5334df102aee0e6798840e8911d96d9870a464337fcc86b6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
  "bs58 0.5.1",
+ "futures",
  "indicatif",
  "log",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "semver",
  "serde",
- "serde_derive",
  "serde_json",
+ "solana-account",
+ "solana-account-decoder",
  "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-epoch-schedule",
+ "solana-feature-gate-interface",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-message",
+ "solana-pubkey 3.0.0",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote-program",
+ "solana-vote-interface",
  "tokio",
 ]
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9ca3a7af9655a401c285f953c22525cad2698913ea4fa28cf217965929f80a"
+checksum = "1c12b2f11d22f67d0be1704c8386e4b30ea5fab2ee9bc5b92b321b533d4b81c6"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
- "bs58 0.5.1",
  "jsonrpc-core",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "reqwest-middleware",
- "semver",
  "serde",
- "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-inline-spl",
- "solana-sdk",
+ "solana-clock",
+ "solana-rpc-client-types",
+ "solana-signer",
+ "solana-transaction-error",
  "solana-transaction-status-client-types",
- "solana-version",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551090640700bbb5f2b593a1f6146603cab53fc13a94120d28180f9941dc9ab2"
+checksum = "bdcf8cd1aad9c762370509d977072720df2aff499a2c4df9a31510d25561e626"
 dependencies = [
+ "solana-account",
+ "solana-commitment-config",
+ "solana-hash 3.1.0",
+ "solana-message",
+ "solana-nonce",
+ "solana-pubkey 3.0.0",
  "solana-rpc-client",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-sdk-ids",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "solana-runtime"
-version = "2.1.11"
+name = "solana-rpc-client-types"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9a95401a49cb8ba751fe4a0fdfa0514c01512f1c0900d3c1f96a2424edb1f"
+checksum = "0e24a1a1bce172a4bcab315ae713fb61e364f8e8151358c7ac04d626a2794212"
 dependencies = [
- "ahash",
- "aquamarine",
- "arrayref",
  "base64 0.22.1",
- "bincode",
- "blake3",
- "bv",
- "bytemuck",
- "byteorder",
- "bzip2",
- "crossbeam-channel",
- "dashmap",
- "dir-diff",
- "flate2",
- "fnv",
- "im",
- "index_list",
- "itertools 0.12.1",
- "lazy_static",
- "libc",
- "log",
- "lz4",
- "memmap2",
- "mockall",
- "modular-bitfield",
- "num-derive",
- "num-traits",
- "num_cpus",
- "num_enum",
- "percentage",
- "qualifier_attr",
- "rand 0.8.5",
- "rayon",
- "regex",
+ "bs58 0.5.1",
+ "semver",
  "serde",
- "serde_derive",
  "serde_json",
- "serde_with",
- "solana-accounts-db",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
- "solana-bucket-map",
- "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-cost-model",
- "solana-feature-set",
- "solana-fee",
- "solana-inline-spl",
- "solana-lattice-hash",
- "solana-loader-v4-program",
- "solana-measure",
- "solana-metrics",
- "solana-perf",
- "solana-program",
- "solana-program-runtime",
- "solana-rayon-threadlimit",
- "solana-runtime-transaction",
- "solana-sdk",
- "solana-stake-program",
- "solana-svm",
- "solana-svm-rent-collector",
- "solana-svm-transaction",
- "solana-system-program",
- "solana-timings",
- "solana-transaction-status",
+ "solana-account",
+ "solana-account-decoder-client-types",
+ "solana-address 1.1.0",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-fee-calculator",
+ "solana-inflation",
+ "solana-reward-info",
+ "solana-transaction",
+ "solana-transaction-error",
+ "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote",
- "solana-vote-program",
- "solana-zk-elgamal-proof-program",
- "solana-zk-sdk",
- "solana-zk-token-proof-program",
- "solana-zk-token-sdk",
- "static_assertions",
- "strum",
- "strum_macros",
- "symlink",
- "tar",
- "tempfile",
- "thiserror 1.0.69",
- "zstd",
-]
-
-[[package]]
-name = "solana-runtime-transaction"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81fb8d51cced94a8822c82efc4fa6d8e9e77e9bb99df026e4289efcbca6bd20"
-dependencies = [
- "agave-transaction-view",
- "log",
- "solana-builtins-default-costs",
- "solana-compute-budget",
- "solana-pubkey",
- "solana-sdk",
- "solana-svm-transaction",
- "thiserror 1.0.69",
+ "spl-generic-token",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-sanitize"
-version = "2.1.11"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c557ff8937946d24c4f188f3029c1fdba4e23a15ed11cc8b31a72017e911d5"
+checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
+
+[[package]]
+name = "solana-sbpf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
+dependencies = [
+ "byteorder",
+ "combine 3.8.1",
+ "hash32",
+ "libc",
+ "log",
+ "rand 0.8.5",
+ "rustc-demangle",
+ "thiserror 2.0.17",
+ "winapi",
+]
 
 [[package]]
 name = "solana-sdk"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d755acdf62b367c1c4ca7ac1069c34a090d281b6425d11dd9410d4a147d99d3"
+checksum = "3f03df7969f5e723ad31b6c9eadccc209037ac4caa34d8dc259316b05c11e82b"
 dependencies = [
  "bincode",
- "bitflags 2.8.0",
- "borsh 1.5.5",
  "bs58 0.5.1",
- "bytemuck",
- "bytemuck_derive",
- "byteorder",
- "chrono",
- "digest 0.10.7",
- "ed25519-dalek",
- "ed25519-dalek-bip32",
- "getrandom 0.1.16",
- "hmac 0.12.1",
- "itertools 0.12.1",
- "js-sys",
- "lazy_static",
- "libsecp256k1",
- "log",
- "memmap2",
- "num-derive",
- "num-traits",
- "num_enum",
- "pbkdf2 0.11.0",
- "rand 0.7.3",
- "rand 0.8.5",
  "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3",
- "siphasher",
  "solana-account",
- "solana-bn254",
- "solana-decode-error",
- "solana-derivation-path",
- "solana-feature-set",
+ "solana-epoch-info",
+ "solana-epoch-rewards-hasher",
+ "solana-fee-structure",
  "solana-inflation",
- "solana-instruction",
- "solana-native-token",
- "solana-packet",
- "solana-precompile-error",
+ "solana-keypair",
+ "solana-message",
+ "solana-offchain-message",
+ "solana-presigner",
  "solana-program",
  "solana-program-memory",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sanitize",
+ "solana-sdk-ids",
  "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-secp256r1-program",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-serde",
  "solana-serde-varint",
  "solana-short-vec",
+ "solana-shred-version",
  "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-transaction",
  "solana-transaction-error",
- "thiserror 1.0.69",
- "wasm-bindgen",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "solana-sdk-ids"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
+dependencies = [
+ "solana-address 2.0.0",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9055600bc70a91936458b3a43a4173f8b8cd4ee64a0dc83cbb00737cadc519a5"
+checksum = "d6430000e97083460b71d9fbadc52a2ab2f88f53b3a4c5e58c5ae3640a0e8c00"
 dependencies = [
  "bs58 0.5.1",
  "proc-macro2",
@@ -5918,28 +5251,13 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-recover"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b904576bfc5b72172aed9c133fe54840625ab9d510bd429d453c54bd6e4245c3"
+checksum = "9de18cfdab99eeb940fbedd8c981fa130c0d76252da75d05446f22fae8b51932"
 dependencies = [
- "borsh 1.5.5",
- "libsecp256k1",
- "solana-define-syscall",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-secp256r1-program"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c1329b7faa66f80bb3dadcece042589d22881120b6c0d0f712f742ad002f26"
-dependencies = [
- "bytemuck",
- "openssl",
- "solana-feature-set",
- "solana-instruction",
- "solana-precompile-error",
- "solana-pubkey",
+ "k256",
+ "solana-define-syscall 4.0.1",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5949,135 +5267,173 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
-name = "solana-send-transaction-service"
-version = "2.1.11"
+name = "solana-seed-derivable"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923a2d80f94052c02550b28a6cea15133e9a100c727f5beda95994e064496b6f"
+checksum = "ff7bdb72758e3bec33ed0e2658a920f1f35dfb9ed576b951d20d63cb61ecd95c"
 dependencies = [
- "crossbeam-channel",
- "log",
- "solana-client",
- "solana-connection-cache",
- "solana-measure",
- "solana-metrics",
- "solana-runtime",
- "solana-sdk",
- "solana-tpu-client",
+ "solana-derivation-path",
+]
+
+[[package]]
+name = "solana-seed-phrase"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
+dependencies = [
+ "hmac",
+ "pbkdf2 0.11.0",
+ "sha2",
+]
+
+[[package]]
+name = "solana-serde"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709a93cab694c70f40b279d497639788fc2ccbcf9b4aa32273d4b361322c02dd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "solana-serde-varint"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e741efbc732c2e33fd600d39a5a5e63cbab18fc75fc84a98df68c2aa2b373b64"
+checksum = "3e5174c57d5ff3c1995f274d17156964664566e2cde18a07bba1586d35a70d3b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "solana-serialize-utils"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6511f5147f992239415bd4bb297ad593da57b4ab634ed9bc10f81a560bc90"
+checksum = "56e41dd8feea239516c623a02f0a81c2367f4b604d7965237fed0751aeec33ed"
 dependencies = [
- "solana-instruction",
- "solana-pubkey",
+ "solana-instruction-error",
+ "solana-pubkey 3.0.0",
  "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3456f5d3868b9ae8e7bc53529bbbd8bee48b0d9cf3783f918269e71e4ee5268d"
+checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
- "sha2 0.10.8",
- "solana-define-syscall",
- "solana-hash",
+ "sha2",
+ "solana-define-syscall 4.0.1",
+ "solana-hash 4.0.1",
 ]
 
 [[package]]
 name = "solana-short-vec"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01771c84475e25352169e3fc901cae565f75ff8c9b40a4fa858f776211f20cbc"
+checksum = "79fb1809a32cfcf7d9c47b7070a92fa17cdb620ab5829e9a8a9ff9d138a7a175"
 dependencies = [
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "solana-shred-version"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94953e22ca28fe4541a3447d6baeaf519cc4ddc063253bfa673b721f34c136bb"
+dependencies = [
+ "solana-hard-forks",
+ "solana-hash 3.1.0",
+ "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f89b547c800c3541d4d5d71de8c82f37a0050f361626213a425ad4f767da27b"
+checksum = "4bb8057cc0e9f7b5e89883d49de6f407df655bb6f3a71d0b7baf9986a2218fd9"
 dependencies = [
- "bs58 0.5.1",
  "ed25519-dalek",
- "generic-array",
+ "five8 0.2.1",
  "rand 0.8.5",
  "serde",
+ "serde-big-array",
  "serde_derive",
  "solana-sanitize",
 ]
 
 [[package]]
-name = "solana-slot-hashes"
-version = "2.1.11"
+name = "solana-signer"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3012c024a81d591d02a10648d5f4256d6fc3c9d93bc5421cadba224794940f6c"
+checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
+dependencies = [
+ "solana-pubkey 3.0.0",
+ "solana-signature",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-slot-hashes"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a293f952293281443c04f4d96afd9d547721923d596e92b4377ed2360f1746"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash",
+ "solana-hash 3.1.0",
+ "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a68e2aae8fbcf00adef67eba05c513b0a461b5ed1fd0bd2cb1299a394a650"
+checksum = "f914f6b108f5bba14a280b458d023e3621c9973f27f015a4d755b50e88d89e97"
 dependencies = [
  "bv",
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-stable-layout"
-version = "2.1.11"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec316bf731aeb8e9e8a55634efb938eaf5c979d71a9e7d3de54f5848da4994a2"
+checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
 dependencies = [
  "solana-instruction",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
-name = "solana-stake-program"
-version = "2.1.11"
+name = "solana-stake-interface"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f968e312060d5fe226a3c90b37a9877bc840a9fd4e6ca2c66570f8383387452f"
+checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
 dependencies = [
- "bincode",
- "log",
- "solana-config-program",
- "solana-feature-set",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-type-overrides",
- "solana-vote-program",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4631cb6e5291e226068e73cf98b4962056eb3c1c32448ce7b8e9f31df522263c"
+checksum = "623840c97214530c492666f473170276e9df77bf9fc62332b67f8ff4ac027e21"
 dependencies = [
- "async-channel",
+ "arc-swap",
  "bytes",
  "crossbeam-channel",
  "dashmap",
@@ -6085,329 +5441,456 @@ dependencies = [
  "futures-util",
  "governor",
  "histogram",
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "itertools 0.12.1",
  "libc",
  "log",
  "nix",
+ "num_cpus",
  "pem 1.1.1",
  "percentage",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.22",
+ "rustls",
  "smallvec",
- "socket2",
+ "socket2 0.6.1",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
+ "solana-packet",
  "solana-perf",
- "solana-sdk",
+ "solana-pubkey 3.0.0",
+ "solana-quic-definitions",
+ "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-tls-utils",
+ "solana-transaction-error",
  "solana-transaction-metrics-tracker",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "x509-parser",
 ]
 
 [[package]]
-name = "solana-svm"
-version = "2.1.11"
+name = "solana-svm-callback"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e393d92d4350e8bda6ad239e50f9a8dfe14162064df4ccc8d5cf5bcd55d6aa"
+checksum = "d50574c1cd55286e56d5382952ceea099ee4a4426c889a3b1e456806f83bdd92"
 dependencies = [
- "itertools 0.12.1",
- "log",
- "percentage",
- "serde",
- "serde_derive",
- "solana-bpf-loader-program",
- "solana-compute-budget",
- "solana-feature-set",
- "solana-fee",
- "solana-loader-v4-program",
- "solana-log-collector",
- "solana-measure",
- "solana-program-runtime",
- "solana-runtime-transaction",
- "solana-sdk",
- "solana-svm-rent-collector",
- "solana-svm-transaction",
- "solana-system-program",
- "solana-timings",
- "solana-type-overrides",
- "solana-vote",
- "thiserror 1.0.69",
+ "solana-account",
+ "solana-clock",
+ "solana-precompile-error",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
-name = "solana-svm-rent-collector"
-version = "2.1.11"
+name = "solana-svm-feature-set"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc203770ae70ebd987e5478a18a370652767117b86fd4782222a03468514e83"
+checksum = "bb4a59053cd2bbee5e85476739707f5030a089457c4140340960260e7aedc2a0"
+
+[[package]]
+name = "solana-svm-log-collector"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6097230b3506b5206088cb248012540f6adff10597a5da0d33c21523c79cdda"
 dependencies = [
- "solana-sdk",
+ "log",
+]
+
+[[package]]
+name = "solana-svm-measure"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55976a874cc3c07e0b1ec2a1177ec420c5608f61a8735c44aef1ca7c73b829d8"
+
+[[package]]
+name = "solana-svm-timings"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3434a3ba8ca342c2c9b4c89ca0b506dbf460f77f6dd1dc7cf0ba804f8d749810"
+dependencies = [
+ "eager",
+ "enum-iterator",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262f8e54be131de086347be7e4149b408a817ba7d2e11864a3aae0076250b94"
+checksum = "db058c2c629ff5dc8fb2cf234d44c0d17d8464f94c62652219de88d83fa65a52"
 dependencies = [
- "solana-sdk",
+ "solana-hash 3.1.0",
+ "solana-message",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-transaction",
 ]
 
 [[package]]
-name = "solana-system-program"
-version = "2.1.11"
+name = "solana-svm-type-overrides"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deec0cbae00fb352cf28baa1dca56826221ed571e49530f497802f65386908c"
+checksum = "f2511decc60b5c1c56d65670b42952b9a9139f0a7fa432a2a7a639c12f71f0e8"
 dependencies = [
- "bincode",
- "log",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+dependencies = [
+ "num-traits",
  "serde",
  "serde_derive",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-type-overrides",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall 4.0.1",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash 4.0.1",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey 4.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-sysvar-id"
-version = "2.1.11"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6ca7b6e6bf9f8c0de74e90546426190385a1c0b8e4d4f1975165f2335f9dc0"
+checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-pubkey",
+ "solana-address 2.0.0",
+ "solana-sdk-ids",
 ]
 
 [[package]]
-name = "solana-thin-client"
-version = "2.1.11"
+name = "solana-time-utils"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581ee5cfdd3c509dc7d744970e5e978dab475fff68058a1198bdaf95e9240eaa"
-dependencies = [
- "bincode",
- "log",
- "rayon",
- "solana-connection-cache",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-sdk",
-]
+checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
-name = "solana-timings"
-version = "2.1.11"
+name = "solana-tls-utils"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f948e963c99cee7d2a14da5faf864cb4ae298f8cb679fc088ec581d9d76aed"
+checksum = "e3173e89d55a1b85e1b86cf1384fb505a2211052e15a6f3aa4a28caf6d6b3c85"
 dependencies = [
- "eager",
- "enum-iterator",
- "solana-sdk",
+ "rustls",
+ "solana-keypair",
+ "solana-pubkey 3.0.0",
+ "solana-signer",
+ "x509-parser",
 ]
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f832646c0c836f54998c07d34980852837ea30de0f383c8eb0b5ad2a60cc05"
+checksum = "2256899a1a9e31c70c1ea707e0b59613eec736503c7adede57accb40c50efef1"
 dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "indicatif",
  "log",
  "rayon",
+ "solana-client-traits",
+ "solana-clock",
+ "solana-commitment-config",
  "solana-connection-cache",
+ "solana-epoch-schedule",
  "solana-measure",
+ "solana-message",
+ "solana-net-utils",
+ "solana-pubkey 3.0.0",
  "solana-pubsub-client",
+ "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction",
+ "solana-transaction-error",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
-name = "solana-transaction-error"
-version = "2.1.11"
+name = "solana-transaction"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a6d17d8de8549df56d64b9af314eec3c4b705372790aa8dde7196e1c5f005"
+checksum = "2ceb2efbf427a91b884709ffac4dac29117752ce1e37e9ae04977e450aa0bb76"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-address 2.0.0",
+ "solana-hash 4.0.1",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-message",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-transaction-context"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017886b71c6c22d15b08967c8d6f9e94f1745a2f01c280d08d22f82d5454bcd1"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-account",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sbpf",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4222065402340d7e6aec9dc3e54d22992ddcf923d91edcd815443c2bfca3144a"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-instruction",
+ "solana-instruction-error",
  "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1906692abc629b5a2a76c76f3006dd4a9e96917000b043fd311d7bfbc24607f2"
+checksum = "43917f2ad4d7faf3028a1fad990a0c5ee30e6e75913c73537eb81049ba171831"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "lazy_static",
  "log",
  "rand 0.8.5",
+ "solana-packet",
  "solana-perf",
- "solana-sdk",
  "solana-short-vec",
+ "solana-signature",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadee373e77a84b180d955847e7f013195b43498e1a8c526c27771e8d0140915"
+checksum = "15be3ad6c8f39beffcb5e5a5c62c87696c3749e9ef20b8ec62544dec101d22a2"
 dependencies = [
  "Inflector",
+ "agave-reserved-account-keys",
  "base64 0.22.1",
  "bincode",
- "borsh 1.5.5",
+ "borsh",
  "bs58 0.5.1",
- "lazy_static",
  "log",
  "serde",
- "serde_derive",
  "serde_json",
  "solana-account-decoder",
- "solana-sdk",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-loader-v2-interface",
+ "solana-loader-v3-interface",
+ "solana-message",
+ "solana-program-option",
+ "solana-pubkey 3.0.0",
+ "solana-reward-info",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-stake-interface",
+ "solana-system-interface",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status-client-types",
- "spl-associated-token-account 4.0.0",
- "spl-memo 5.0.0",
- "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
- "spl-token-group-interface 0.3.0",
- "spl-token-metadata-interface 0.4.0",
- "thiserror 1.0.69",
+ "solana-vote-interface",
+ "spl-associated-token-account-interface",
+ "spl-memo-interface",
+ "spl-token-2022-interface",
+ "spl-token-group-interface",
+ "spl-token-interface",
+ "spl-token-metadata-interface",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc4018fa5363ccf0932b26821abf47c226f52fb865b2944d1f29db83a11774a"
+checksum = "8b3cb8c718af0245ab3b84324f856661d87e29f193c0c0125ed0a4c212814d61"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "bs58 0.5.1",
  "serde",
- "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-sdk",
+ "solana-commitment-config",
+ "solana-instruction",
+ "solana-message",
+ "solana-pubkey 3.0.0",
+ "solana-reward-info",
  "solana-signature",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-type-overrides"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9673b27fb01b5479a25bfdd83d5ea1112433c8cf81a0aa8616c829587b285ecd"
-dependencies = [
- "lazy_static",
- "rand 0.8.5",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a073d7abe99c118378562f2f39037b5f66f926c668cc1162de327b20bbd82c"
+checksum = "acf297ba743dee44f1a011b06bbdcbd7cb4a6444ae8b42148de7818b007f6078"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-net-utils",
- "solana-sdk",
  "solana-streamer",
- "thiserror 1.0.69",
+ "solana-transaction-error",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "solana-version"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce3a7b94b3772a3dc66b28f2b6abc7b4b510dbc36387b618398111acc26ec57"
+checksum = "4d1c28ae4e600f7b2b76cce76696c7ee4ab2078f5428125d04ed31c421dfb122"
 dependencies = [
+ "agave-feature-set",
+ "rand 0.8.5",
  "semver",
  "serde",
- "serde_derive",
- "solana-feature-set",
  "solana-sanitize",
  "solana-serde-varint",
 ]
 
 [[package]]
-name = "solana-vote"
-version = "2.1.11"
+name = "solana-vote-interface"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1a73fa59c07095599091dd9f026aceb478109d61d41720883a22ead9c18f8e"
+checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
 dependencies = [
- "itertools 0.12.1",
- "log",
+ "bincode",
+ "cfg_eval",
+ "num-derive",
+ "num-traits",
  "serde",
  "serde_derive",
- "solana-sdk",
- "thiserror 1.0.69",
+ "serde_with",
+ "solana-clock",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-serde-varint",
+ "solana-serialize-utils",
+ "solana-short-vec",
+ "solana-system-interface",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "2.1.11"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573944c767e4908d6ba12151029cb9ac33b49e7082991c6d978d3ab83ac68d6b"
+checksum = "ed2d2e3bfbb9c8e365f38338fa30875d2692b51057d24e776744af3d4455d06d"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "log",
  "num-derive",
  "num-traits",
  "serde",
- "serde_derive",
- "solana-feature-set",
- "solana-metrics",
- "solana-program",
+ "solana-account",
+ "solana-bincode",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-packet",
  "solana-program-runtime",
- "solana-sdk",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-zk-elgamal-proof-program"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6724fc3e23968c89d5c0a4642704c6f3610b91aaab6aaf57712091cdaad089"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-sdk",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-signer",
+ "solana-slot-hashes",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-vote-interface",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.1.11"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5f33e61ecb86621dd7b47e164ec09021b0c910a79e3a6b17ae763554ad7138"
+checksum = "9602bcb1f7af15caef92b91132ec2347e1c51a72ecdbefdaefa3eac4b8711475"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
  "bincode",
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
+ "getrandom 0.2.15",
  "itertools 0.12.1",
  "js-sys",
- "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
@@ -6417,78 +5900,17 @@ dependencies = [
  "serde_json",
  "sha3",
  "solana-derivation-path",
- "solana-program",
- "solana-sdk",
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "wasm-bindgen",
  "zeroize",
-]
-
-[[package]]
-name = "solana-zk-token-proof-program"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8688e2ff758c51218712659de5ca3718a6521720e3edb866d72670d9566152b"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-feature-set",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-token-sdk",
-]
-
-[[package]]
-name = "solana-zk-token-sdk"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9c007da85c5be2273c96647e4070bf69b2fda7ba43cddf5eab84c14b2fad67"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "byteorder",
- "curve25519-dalek 4.1.3",
- "itertools 0.12.1",
- "lazy_static",
- "merlin",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "solana-curve25519",
- "solana-derivation-path",
- "solana-program",
- "solana-sdk",
- "subtle",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "solana_rbpf"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1941b5ef0c3ce8f2ac5dd984d0fb1a97423c4ff2a02eec81e3913f02e2ac2b"
-dependencies = [
- "byteorder",
- "combine 3.8.1",
- "hash32",
- "libc",
- "log",
- "rand 0.8.5",
- "rustc-demangle",
- "scroll",
- "thiserror 1.0.69",
- "winapi",
 ]
 
 [[package]]
@@ -6518,86 +5940,51 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "4.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68034596cf4804880d265f834af1ff2f821ad5293e41fa0f8f59086c181fc38e"
+checksum = "0242277e290c023de8826f504abcf9206b3cd4e18d9ace4ec59a698b2828e88b"
 dependencies = [
- "assert_matches",
- "borsh 1.5.5",
+ "borsh",
  "num-derive",
  "num-traits",
- "solana-program",
- "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
- "thiserror 1.0.69",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "solana-sysvar",
+ "spl-associated-token-account-interface",
+ "spl-token-2022-interface",
+ "spl-token-interface",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "6.0.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "borsh 1.5.5",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-associated-token-account-client 2.0.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-token 7.0.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-token-2022 6.0.0",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-associated-token-account-client"
+name = "spl-associated-token-account-interface"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
+checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
 dependencies = [
+ "borsh",
  "solana-instruction",
- "solana-pubkey",
-]
-
-[[package]]
-name = "spl-associated-token-account-client"
-version = "2.0.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "solana-instruction",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
 name = "spl-discriminator"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38ea8b6dedb7065887f12d62ed62c1743aa70749e8558f963609793f6fb12bc"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.4.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
+checksum = "d48cc11459e265d5b501534144266620289720b4c44522a47bc6b63cd295d2f3"
 dependencies = [
  "bytemuck",
  "solana-program-error",
  "solana-sha256-hasher",
- "spl-discriminator-derive 0.2.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7398da23554a31660f17718164e31d31900956054f54f52d5ec1be51cb4f4b3"
-dependencies = [
- "bytemuck",
- "solana-program-error",
- "solana-sha256-hasher",
- "spl-discriminator-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator-derive",
 ]
 
 [[package]]
@@ -6607,17 +5994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
- "spl-discriminator-syn 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "spl-discriminator-derive"
-version = "0.2.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "quote",
- "spl-discriminator-syn 0.2.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
+ "spl-discriminator-syn",
  "syn 2.0.96",
 ]
 
@@ -6629,429 +6006,276 @@ checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.8",
- "syn 2.0.96",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-discriminator-syn"
-version = "0.2.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
+ "sha2",
  "syn 2.0.96",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "spl-elgamal-registry"
-version = "0.1.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd22edf24c47c4610b160f49c12fe33b19aec2a0968e3c9cd412fa2a94ae2bb"
 dependencies = [
  "bytemuck",
- "solana-program",
- "solana-zk-sdk",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-token-confidential-transfer-proof-extraction 0.2.0",
-]
-
-[[package]]
-name = "spl-elgamal-registry"
-version = "0.1.1"
-source = "git+https://github.com/kilogold/token-2022.git?branch=cli_transaction_generation#08743234b3871aea09ea2ac392c53c1925fd2000"
-dependencies = [
- "bytemuck",
- "solana-program",
- "solana-zk-sdk",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
-]
-
-[[package]]
-name = "spl-memo"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0dba2f2bb6419523405d21c301a32c9f9568354d4742552e7972af801f4bdb3"
-dependencies = [
- "solana-program",
-]
-
-[[package]]
-name = "spl-memo"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
-dependencies = [
  "solana-account-info",
+ "solana-cpi",
  "solana-instruction",
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-security-txt",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-zk-sdk",
+ "spl-elgamal-registry-interface",
+ "spl-pod",
+ "spl-token-confidential-transfer-proof-extraction",
 ]
 
 [[package]]
-name = "spl-pod"
-version = "0.3.1"
+name = "spl-elgamal-registry-interface"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c704c88fc457fa649ba3aabe195c79d885c3f26709efaddc453c8de352c90b87"
+checksum = "065f54100d118d24036283e03120b2f60cb5b7d597d3db649e13690e22d41398"
 dependencies = [
- "borsh 1.5.5",
  "bytemuck",
- "bytemuck_derive",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-program-error 0.5.0",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-zk-sdk",
+ "spl-token-confidential-transfer-proof-extraction",
+]
+
+[[package]]
+name = "spl-generic-token"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233df81b75ab99b42f002b5cdd6e65a7505ffa930624f7096a7580a56765e9cf"
+dependencies = [
+ "bytemuck",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "spl-memo-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4e2aedd58f858337fa609af5ad7100d4a243fdaf6a40d6eb4c28c5f19505d3"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
 name = "spl-pod"
-version = "0.5.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a7d5950993e1ff2680bd989df298eeb169367fb2f9deeef1f132de6e4e8016"
+checksum = "b1233fdecd7461611d69bb87bc2e95af742df47291975d21232a0be8217da9de"
 dependencies = [
- "borsh 1.5.5",
+ "borsh",
  "bytemuck",
  "bytemuck_derive",
  "num-derive",
  "num-traits",
- "solana-decode-error",
- "solana-msg",
+ "num_enum",
  "solana-program-error",
  "solana-program-option",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-zk-sdk",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "spl-pod"
-version = "0.5.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
+name = "spl-program-error"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4f6cf26cb6768110bf024bc7224326c720d711f7ad25d16f40f6cee40edb2d"
 dependencies = [
- "borsh 1.5.5",
- "bytemuck",
- "bytemuck_derive",
  "num-derive",
  "num-traits",
- "solana-decode-error",
+ "num_enum",
  "solana-msg",
  "solana-program-error",
- "solana-program-option",
- "solana-pubkey",
- "solana-zk-sdk",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b28bed65356558133751cc32b48a7a5ddfc59ac4e941314630bbed1ac10532"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-program-error-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d39b5186f42b2b50168029d81e58e800b690877ef0b30580d107659250da1d1"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-program-error-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.6.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-program-error-derive 0.4.1 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
+ "spl-program-error-derive",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
+checksum = "9ec8965aa4dc6c74701cbb48b9cad5af35b9a394514934949edbb357b78f840d"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.8",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.4.1"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
+ "sha2",
  "syn 2.0.96",
 ]
 
 [[package]]
 name = "spl-record"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1288810a85bbe7e62ee3c6f7b8119e8c1016e90351411d12e4132e98c7ca7344"
+checksum = "fda0eb42ca6387770d7f0e764ecd8fa863f4529e9ff35fbf146576b5f4372587"
 dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
  "solana-account-info",
- "solana-decode-error",
  "solana-instruction",
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-pack",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-rent",
- "thiserror 1.0.69",
+ "solana-security-txt",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.7.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a75a5f0fcc58126693ed78a17042e9dc53f07e357d6be91789f7d62aff61a4"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd99ff1e9ed2ab86e3fd582850d47a739fec1be9f4661cba1782d3a0f26805f3"
+checksum = "6927f613c9d7ce20835d3cefb602137cab2518e383a047c0eaa58054a60644c8"
 dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
+ "num_enum",
  "solana-account-info",
- "solana-decode-error",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552427d9117528d037daa0e70416d51322c8a33241317210f230304d852be61e"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-clock",
+ "solana-cpi",
  "solana-instruction",
  "solana-msg",
+ "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-security-txt",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-zk-sdk",
+ "spl-elgamal-registry-interface",
+ "spl-memo-interface",
+ "spl-pod",
+ "spl-token-2022-interface",
+ "spl-token-confidential-transfer-ciphertext-arithmetic",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "spl-tlv-account-resolution"
-version = "0.9.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
+name = "spl-token-2022-interface"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcd81188211f4b3c8a5eba7fd534c7142f9dd026123b3472492782cc72f4dc6"
 dependencies = [
+ "arrayref",
  "bytemuck",
  "num-derive",
  "num-traits",
+ "num_enum",
  "solana-account-info",
- "solana-decode-error",
  "solana-instruction",
- "solana-msg",
  "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.0",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-program-error 0.6.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-type-length-value 0.7.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-token"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a0f06ac7f23dc0984931b1fe309468f14ea58e32660439c1cef19456f5d0e3"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed320a6c934128d4f7e54fe00e16b8aeaecf215799d060ae14f93378da6dc834"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token"
-version = "7.0.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c10f3483e48679619c76598d4e4aebb955bc49b0a5cc63323afbf44135c9bf"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-security-txt",
- "solana-zk-token-sdk",
- "spl-memo 5.0.0",
- "spl-pod 0.3.1",
- "spl-token 6.0.0",
- "spl-token-group-interface 0.3.0",
- "spl-token-metadata-interface 0.4.0",
- "spl-transfer-hook-interface 0.7.0",
- "spl-type-length-value 0.5.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "6.0.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-security-txt",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
  "solana-zk-sdk",
- "spl-elgamal-registry 0.1.0",
- "spl-memo 6.0.0",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-token 7.0.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.0",
- "spl-token-confidential-transfer-proof-extraction 0.2.0",
- "spl-token-confidential-transfer-proof-generation 0.2.0",
- "spl-token-group-interface 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-token-metadata-interface 0.6.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-transfer-hook-interface 0.9.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-type-length-value 0.7.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "7.0.0"
-source = "git+https://github.com/kilogold/token-2022.git?branch=cli_transaction_generation#08743234b3871aea09ea2ac392c53c1925fd2000"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-security-txt",
- "solana-zk-sdk",
- "spl-elgamal-registry 0.1.1",
- "spl-memo 6.0.0",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
- "spl-token-confidential-transfer-proof-generation 0.3.0",
- "spl-token-group-interface 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-metadata-interface 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-transfer-hook-interface 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.11",
+ "spl-pod",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
+ "spl-type-length-value",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "spl-token-client"
-version = "0.14.0"
-source = "git+https://github.com/kilogold/token-2022.git?branch=cli_transaction_generation#08743234b3871aea09ea2ac392c53c1925fd2000"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f87005f510593cc674a4f9f257bedbecfbb35f5aae1b66a65ef9b7dbccdeb5"
 dependencies = [
  "async-trait",
  "bincode",
  "bytemuck",
  "futures",
  "futures-util",
- "solana-banks-interface",
+ "solana-account",
  "solana-cli-output",
- "solana-program-test",
+ "solana-compute-budget-interface",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-message",
+ "solana-packet",
+ "solana-program-error",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk",
- "spl-associated-token-account-client 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-elgamal-registry 0.1.1",
- "spl-memo 6.0.0",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
+ "spl-associated-token-account-interface",
+ "spl-elgamal-registry",
+ "spl-memo-interface",
  "spl-record",
- "spl-token 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 7.0.0",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
- "spl-token-confidential-transfer-proof-generation 0.3.0",
- "spl-token-group-interface 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-metadata-interface 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-transfer-hook-interface 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.11",
+ "spl-token-2022",
+ "spl-token-2022-interface",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation",
+ "spl-token-group-interface",
+ "spl-token-interface",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface",
+ "thiserror 2.0.17",
+ "tokio",
 ]
 
 [[package]]
 name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.2.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.2.1"
-source = "git+https://github.com/kilogold/token-2022.git?branch=cli_transaction_generation#08743234b3871aea09ea2ac392c53c1925fd2000"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afbeb07f737d868f145512a4bcf9f59da275b7a3483df0add3f71eb812b689fb"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -7061,176 +6285,97 @@ dependencies = [
 
 [[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.2.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879a9ebad0d77383d3ea71e7de50503554961ff0f4ef6cbca39ad126e6f6da3a"
 dependencies = [
  "bytemuck",
+ "solana-account-info",
  "solana-curve25519",
- "solana-program",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
  "solana-zk-sdk",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.2.1"
-source = "git+https://github.com/kilogold/token-2022.git?branch=cli_transaction_generation#08743234b3871aea09ea2ac392c53c1925fd2000"
-dependencies = [
- "bytemuck",
- "solana-curve25519",
- "solana-program",
- "solana-zk-sdk",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.11",
+ "spl-pod",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "spl-token-confidential-transfer-proof-generation"
-version = "0.2.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0cd59fce3dc00f563c6fa364d67c3f200d278eae681f4dc250240afcfe044b1"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "solana-zk-sdk",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.3.0"
-source = "git+https://github.com/kilogold/token-2022.git?branch=cli_transaction_generation#08743234b3871aea09ea2ac392c53c1925fd2000"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
- "thiserror 2.0.11",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "spl-token-group-interface"
-version = "0.3.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8752b85a5ecc1d9f3a43bce3dd9a6a053673aacf5deb513d1cbb88d3534ffd"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d595667ed72dbfed8c251708f406d7c2814a3fa6879893b323d56a10bedfc799"
+checksum = "452d0f758af20caaa10d9a6f7608232e000d4c74462f248540b3d2ddfa419776"
 dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
- "solana-decode-error",
+ "num_enum",
  "solana-instruction",
- "solana-msg",
  "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
+ "solana-pubkey 3.0.0",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "spl-token-group-interface"
-version = "0.5.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.0",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.4.0"
+name = "spl-token-interface"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
-dependencies = [
- "borsh 1.5.5",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb9c89dbc877abd735f05547dcf9e6e12c00c11d6d74d8817506cab4c99fdbb"
-dependencies = [
- "borsh 1.5.5",
- "num-derive",
- "num-traits",
- "solana-borsh",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.6.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "borsh 1.5.5",
- "num-derive",
- "num-traits",
- "solana-borsh",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.0",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-type-length-value 0.7.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a110f33d941275d9f868b96daaa993f1e73b6806cc8836e43075b4d3ad8338a7"
+checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
 dependencies = [
  "arrayref",
  "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
- "spl-tlv-account-resolution 0.7.0",
- "spl-type-length-value 0.5.0",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c467c7c3bd056f8fe60119e7ec34ddd6f23052c2fa8f1f51999098063b72676"
+dependencies = [
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-borsh",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-type-length-value",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.9.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa7503d52107c33c88e845e1351565050362c2314036ddf19a36cd25137c043"
+checksum = "c34b46b8f39bc64a9ab177a0ea8e9a58826db76f8d9d154a2400ee60baef7b1e"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7238,89 +6383,36 @@ dependencies = [
  "num-traits",
  "solana-account-info",
  "solana-cpi",
- "solana-decode-error",
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-tlv-account-resolution 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-type-length-value",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "spl-transfer-hook-interface"
+name = "spl-type-length-value"
 version = "0.9.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator 0.4.0",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-program-error 0.6.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-tlv-account-resolution 0.9.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "spl-type-length-value 0.7.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcd73ec187bc409464c60759232e309f83b52a18a9c5610bf281c9c6432918c"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba70ef09b13af616a4c987797870122863cba03acc4284f226a4473b043923f9"
+checksum = "ca20a1a19f4507a98ca4b28ff5ed54cac9b9d34ed27863e2bde50a3238f9a6ac"
 dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
+ "num_enum",
  "solana-account-info",
- "solana-decode-error",
  "solana-msg",
  "solana-program-error",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.7.0"
-source = "git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da#224a96b164357a221c7f7dae5e348f9c0f7a73da"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-discriminator 0.4.0",
- "spl-pod 0.5.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=224a96b164357a221c7f7dae5e348f9c0f7a73da)",
- "thiserror 2.0.11",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7328,12 +6420,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -7348,38 +6434,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -7448,7 +6506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -7459,7 +6517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -7484,59 +6542,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.43"
+name = "tap"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
-name = "tarpc"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38a012bed6fb9681d3bf71ffaa4f88f3b4b9ed3198cda6e4c8462d24d4bb80"
-dependencies = [
- "anyhow",
- "fnv",
- "futures",
- "humantime",
- "opentelemetry",
- "pin-project",
- "rand 0.8.5",
- "serde",
- "static_assertions",
- "tarpc-plugins",
- "thiserror 1.0.69",
- "tokio",
- "tokio-serde",
- "tokio-util 0.6.10",
- "tracing",
- "tracing-opentelemetry",
-]
-
-[[package]]
-name = "tarpc-plugins"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -7551,21 +6560,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -7587,11 +6581,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -7607,9 +6601,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7617,13 +6611,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
+name = "threadpool"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
- "cfg-if",
- "once_cell",
+ "num_cpus",
 ]
 
 [[package]]
@@ -7659,17 +6652,15 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
- "anyhow",
- "hmac 0.8.1",
  "once_cell",
- "pbkdf2 0.4.0",
- "rand 0.7.3",
+ "pbkdf2 0.12.2",
+ "rand 0.8.5",
  "rustc-hash 1.1.0",
- "sha2 0.9.9",
+ "sha2",
  "thiserror 1.0.69",
  "unicode-normalization",
  "wasm-bindgen",
@@ -7702,46 +6693,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tk-rs"
-version = "0.1.0"
-source = "git+https://github.com/kilogold/tk-rs.git#5ebfdbb230d527821e2958948c1a0cce17e98278"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "chrono",
- "hex",
- "p256",
- "reqwest 0.12.12",
- "serde",
- "serde_json",
- "solana-program",
- "solana-sdk",
- "tokio",
-]
-
-[[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7770,38 +6742,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.22",
+ "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
-dependencies = [
- "bincode",
- "bytes",
- "educe",
- "futures-core",
- "futures-sink",
- "pin-project",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -7817,54 +6763,32 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.12",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
- "webpki-roots 0.25.4",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
- "pin-project-lite",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7879,7 +6803,7 @@ version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.13.0",
  "toml_datetime",
  "winnow",
 ]
@@ -7900,16 +6824,16 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
  "rustls-pemfile 2.2.0",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -7932,7 +6856,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7949,6 +6873,29 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "bitflags 2.8.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -7995,31 +6942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -8031,13 +6953,14 @@ dependencies = [
  "bytemuck",
  "jito-sdk-rust",
  "serde_json",
+ "solana-client",
  "solana-sdk",
- "solana-zk-sdk",
- "spl-associated-token-account 6.0.0",
- "spl-token-2022 7.0.0",
+ "solana-system-interface",
+ "spl-associated-token-account",
+ "spl-token-2022",
  "spl-token-client",
- "spl-token-confidential-transfer-proof-extraction 0.2.1",
- "spl-token-confidential-transfer-proof-generation 0.3.0",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation",
  "utils",
 ]
 
@@ -8049,23 +6972,22 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http 1.2.0",
  "httparse",
  "log",
- "rand 0.8.5",
- "rustls 0.21.12",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
- "url",
+ "thiserror 2.0.17",
  "utf-8",
- "webpki-roots 0.24.0",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -8073,12 +6995,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -8112,6 +7028,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
@@ -8156,13 +7078,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -8197,22 +7120,23 @@ dependencies = [
  "bs58 0.5.1",
  "dotenvy",
  "google-cloud-kms",
+ "hex",
  "jito-sdk-rust",
- "reqwest 0.12.12",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "solana-client",
+ "solana-commitment-config",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-native-token",
+ "solana-pubkey 3.0.0",
  "solana-sdk",
- "solana-zk-sdk",
- "tk-rs",
+ "solana-signer",
+ "solana-system-interface",
+ "spl-token-2022",
  "tokio",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -8256,12 +7180,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -8371,33 +7289,27 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.24.0"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
- "rustls-webpki 0.101.7",
+ "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8443,33 +7355,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -8500,6 +7426,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8523,12 +7482,35 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -8543,6 +7525,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8553,6 +7547,18 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8567,10 +7573,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8585,6 +7609,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8595,6 +7631,18 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8609,6 +7657,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8619,6 +7679,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -8653,10 +7719,10 @@ name = "withdraw_tokens"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "spl-associated-token-account 6.0.0",
- "spl-token-2022 7.0.0",
+ "spl-associated-token-account",
+ "spl-token-2022",
  "spl-token-client",
- "spl-token-confidential-transfer-proof-generation 0.3.0",
+ "spl-token-confidential-transfer-proof-generation",
  "utils",
 ]
 
@@ -8671,6 +7737,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x509-parser"
@@ -8688,17 +7763,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
-]
-
-[[package]]
-name = "xattr"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
-dependencies = [
- "libc",
- "linux-raw-sys",
- "rustix",
 ]
 
 [[package]]
@@ -8810,10 +7874,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd"
-version = "0.13.2"
+name = "zmij"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,19 @@ members = [
 
 [workspace.dependencies]
 # Solana dependencies
-solana-sdk = "2.1.11"
-solana-client = "2.1.11"
-solana-transaction-status-client-types = "2.1.11"
-solana-zk-sdk = "2.1.11"
+solana-sdk = "3.0.0"
+solana-client = "3.1.6"
+solana-transaction-status-client-types = "3.1.6"
 
 # SPL dependencies
-spl-token-2022 = { git = "https://github.com/kilogold/token-2022.git", branch = "cli_transaction_generation" }
-spl-token-client = { git = "https://github.com/kilogold/token-2022.git", branch = "cli_transaction_generation" }
-spl-associated-token-account = { git = "https://github.com/solana-labs/solana-program-library.git", rev = "224a96b164357a221c7f7dae5e348f9c0f7a73da" }
-spl-token-confidential-transfer-proof-generation = { git = "https://github.com/kilogold/token-2022.git", branch = "cli_transaction_generation" }
-spl-token-confidential-transfer-proof-extraction = { git = "https://github.com/kilogold/token-2022.git", branch = "cli_transaction_generation" }
+spl-token-2022 = "10.0.0"
+spl-token-2022-interface = "2.1.0"
+spl-token-client = "0.18.0"
+spl-associated-token-account = "8.0.0"
+spl-token-confidential-transfer-proof-generation = "0.5.1"
+spl-token-confidential-transfer-proof-extraction = "0.5.1"
 
 # Other dependencies
-tk-rs = { git = "https://github.com/kilogold/tk-rs.git" }
 tokio = { version = "1.42.0", features = ["full"] }
 serde = "1.0.215"
 serde_json = "1.0.1"

--- a/ingredients/apply_pending_balance/Cargo.toml
+++ b/ingredients/apply_pending_balance/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 utils = { path = "../../utils" }
 solana-sdk = { workspace = true }
 spl-token-2022 = { workspace = true }
+spl-token-2022-interface = { workspace = true }
 spl-token-client = { workspace = true }
 spl-associated-token-account = { workspace = true }

--- a/ingredients/apply_pending_balance/src/lib.rs
+++ b/ingredients/apply_pending_balance/src/lib.rs
@@ -1,27 +1,29 @@
 use std::{error::Error, sync::Arc};
 
-use utils::{
-    get_non_blocking_rpc_client, get_or_create_keypair, get_rpc_client, load_value, print_transaction_url,
-};
 use solana_sdk::{signer::Signer, transaction::Transaction};
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
     error::TokenError,
     extension::{
-        confidential_transfer::{
-            account_info::ApplyPendingBalanceAccountInfo, instruction, ConfidentialTransferAccount,
-        },
+        confidential_transfer::account_info::ApplyPendingBalanceAccountInfo,
         BaseStateWithExtensions,
     },
     solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
+};
+use spl_token_2022_interface::extension::confidential_transfer::{
+    instruction, ConfidentialTransferAccount,
 };
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::Token,
 };
+use utils::{
+    get_non_blocking_rpc_client, get_or_create_keypair, get_rpc_client, load_value,
+    print_transaction_url,
+};
 
 pub async fn apply_pending_balance(
-    token_account_authority: &dyn Signer
+    token_account_authority: &dyn Signer,
 ) -> Result<(), Box<dyn Error>> {
     let fee_payer_keypair = Arc::new(get_or_create_keypair("fee_payer_keypair")?);
     let client = get_rpc_client()?;
@@ -33,13 +35,13 @@ pub async fn apply_pending_balance(
         &mint.pubkey(),
         &spl_token_2022::id(),
     );
-    
+
     let sender_elgamal_keypair =
         ElGamalKeypair::new_from_signer(&token_account_authority, &token_account_pubkey.to_bytes())
             .unwrap();
     let sender_aes_key =
         AeKey::new_from_signer(&token_account_authority, &token_account_pubkey.to_bytes()).unwrap();
-    
+
     // The "pending" balance must be applied to "available" balance before it can be transferred
 
     // A "non-blocking" RPC client (for async calls)
@@ -60,9 +62,7 @@ pub async fn apply_pending_balance(
     };
 
     // Get sender token account data
-    let token_account_info = token
-        .get_account_info(&token_account_pubkey)
-        .await?;
+    let token_account_info = token.get_account_info(&token_account_pubkey).await?;
 
     // Unpack the ConfidentialTransferAccount extension portion of the token account data
     let confidential_transfer_account =
@@ -84,11 +84,11 @@ pub async fn apply_pending_balance(
     // Create a `ApplyPendingBalance` instruction
     let apply_pending_balance_instruction = instruction::apply_pending_balance(
         &spl_token_2022::id(),
-        &token_account_pubkey,         // Token account
+        &token_account_pubkey,                     // Token account
         expected_pending_balance_credit_counter, // Expected number of times the pending balance has been credited
         &new_decryptable_available_balance.into(), // Cipher text of the new decryptable available balance
-        &token_account_authority.pubkey(),                       // Token account owner
-        &[&token_account_authority.pubkey()],                    // Additional signers
+        &token_account_authority.pubkey(),         // Token account owner
+        &[&token_account_authority.pubkey()],      // Additional signers
     )?;
 
     let recent_blockhash = client.get_latest_blockhash()?;

--- a/ingredients/deposit_tokens/src/lib.rs
+++ b/ingredients/deposit_tokens/src/lib.rs
@@ -1,11 +1,14 @@
 use std::error::Error;
 
-use utils::{get_or_create_keypair, get_rpc_client, load_value, print_transaction_url};
 use solana_sdk::{signer::Signer, transaction::Transaction};
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::extension::confidential_transfer::instruction::deposit;
+use utils::{get_or_create_keypair, get_rpc_client, load_value, print_transaction_url};
 
-pub async fn deposit_tokens(deposit_amount: u64, depositor_signer: &dyn Signer) -> Result<(), Box<dyn Error>> {
+pub async fn deposit_tokens(
+    deposit_amount: u64,
+    depositor_signer: &dyn Signer,
+) -> Result<(), Box<dyn Error>> {
     let client = get_rpc_client()?;
     let mint = get_or_create_keypair("mint")?;
     let decimals = load_value("mint_decimals")?;
@@ -15,19 +18,19 @@ pub async fn deposit_tokens(deposit_amount: u64, depositor_signer: &dyn Signer) 
 
     let depositor_token_account = get_associated_token_address_with_program_id(
         &depositor_signer.pubkey(), // Token account owner
-        &mint.pubkey(),        // Mint
+        &mint.pubkey(),             // Mint
         &spl_token_2022::id(),
     );
 
     // Instruction to deposit from non-confidential balance to "pending" balance
     let deposit_instruction = deposit(
         &spl_token_2022::id(),
-        &depositor_token_account, // Token account
-        &mint.pubkey(),                   // Mint
-        deposit_amount,                   // Amount to deposit
-        decimals,                         // Mint decimals
-        &depositor_signer.pubkey(),               // Token account owner
-        &[&depositor_signer.pubkey()],            // Signers
+        &depositor_token_account,      // Token account
+        &mint.pubkey(),                // Mint
+        deposit_amount,                // Amount to deposit
+        decimals,                      // Mint decimals
+        &depositor_signer.pubkey(),    // Token account owner
+        &[&depositor_signer.pubkey()], // Signers
     )?;
 
     let recent_blockhash = client.get_latest_blockhash()?;

--- a/ingredients/global_auditor_assert/Cargo.toml
+++ b/ingredients/global_auditor_assert/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 solana-sdk = { workspace = true }
 solana-client = { workspace = true }
+solana-commitment-config = "3.0.0"
 solana-transaction-status-client-types = { workspace = true }
 spl-token-2022 = { workspace = true }
 spl-token-confidential-transfer-proof-generation = { workspace = true }

--- a/ingredients/global_auditor_assert/src/lib.rs
+++ b/ingredients/global_auditor_assert/src/lib.rs
@@ -1,21 +1,23 @@
 use std::{error::Error, str::FromStr};
 
-use utils::{get_rpc_client, load_value};
 use bs58;
 use solana_client::rpc_config::RpcTransactionConfig;
 use solana_transaction_status_client_types::{
     EncodedTransaction, UiMessage, UiTransactionEncoding,
 };
 use spl_token_2022::{
-    extension::confidential_transfer::instruction::TransferInstructionData, instruction::decode_instruction_data, solana_zk_sdk::encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair}
+    extension::confidential_transfer::instruction::TransferInstructionData,
+    instruction::decode_instruction_data,
+    solana_zk_sdk::encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair},
 };
+use utils::{get_rpc_client, load_value};
 
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::Signature,
+use solana_commitment_config::CommitmentConfig;
+use solana_sdk::signature::Signature;
+
+use spl_token_confidential_transfer_proof_generation::{
+    try_combine_lo_hi_ciphertexts, TRANSFER_AMOUNT_LO_BITS,
 };
-
-use spl_token_confidential_transfer_proof_generation::{try_combine_lo_hi_ciphertexts, TRANSFER_AMOUNT_LO_BITS};
 
 pub async fn last_transfer_amount(
     asserting_amount: u64,
@@ -29,7 +31,7 @@ pub async fn last_transfer_amount(
 
     // Get the RPC client to interact with the blockchain
     let client = get_rpc_client()?;
-    
+
     // Configure the transaction request with specific encoding and commitment settings
     let config = RpcTransactionConfig {
         encoding: Some(UiTransactionEncoding::Json),
@@ -44,17 +46,17 @@ pub async fn last_transfer_amount(
     match tx.transaction.transaction {
         EncodedTransaction::Json(ui_transaction) => {
             if let UiMessage::Raw(raw_message) = ui_transaction.message {
-                
                 // Decode the base58 encoded instruction data
                 let input = bs58::decode(raw_message.instructions[0].data.clone())
                     .into_vec()
-                    .map_err(|e| format!("Base58 decode error: {:?}", e))?;                
+                    .map_err(|e| format!("Base58 decode error: {:?}", e))?;
 
                 // Trim the token instruction type from the input
                 let input = &input[1..];
 
                 // Decode the instruction data into a TransferInstructionData object
-                let decoded_instruction: TransferInstructionData = *decode_instruction_data(&input)?;
+                let decoded_instruction: TransferInstructionData =
+                    *decode_instruction_data(&input)?;
 
                 // Extract and convert the low and high ciphertext parts
                 let ct_pod_lo = decoded_instruction.transfer_amount_auditor_ciphertext_lo;
@@ -63,17 +65,19 @@ pub async fn last_transfer_amount(
                 let ct_hi = ElGamalCiphertext::try_from(ct_pod_hi)?;
 
                 // Combine the low and high ciphertexts to get the full transfer amount ciphertext
-                let transfer_amount_auditor_ciphertext = try_combine_lo_hi_ciphertexts(
-                    &ct_lo,
-                    &ct_hi,
-                    TRANSFER_AMOUNT_LO_BITS,
-                ).ok_or(format!("Failed to combine ciphertexts"))?;
+                let transfer_amount_auditor_ciphertext =
+                    try_combine_lo_hi_ciphertexts(&ct_lo, &ct_hi, TRANSFER_AMOUNT_LO_BITS)
+                        .ok_or(format!("Failed to combine ciphertexts"))?;
 
                 // Decrypt the transfer amount using the auditor's secret key
-                let decrypted_amount = auditor_keypair.secret().decrypt(&transfer_amount_auditor_ciphertext);
+                let decrypted_amount = auditor_keypair
+                    .secret()
+                    .decrypt(&transfer_amount_auditor_ciphertext);
 
                 // Decode the decrypted amount and assert it matches the expected asserting amount
-                let decrypted_decoded_amount = decrypted_amount.decode_u32().ok_or(format!("Failed to decode u32"))?;
+                let decrypted_decoded_amount = decrypted_amount
+                    .decode_u32()
+                    .ok_or(format!("Failed to decode u32"))?;
                 assert_eq!(decrypted_decoded_amount, asserting_amount);
             }
         }

--- a/ingredients/mint_tokens/Cargo.toml
+++ b/ingredients/mint_tokens/Cargo.toml
@@ -11,4 +11,3 @@ spl-associated-token-account = { workspace = true }
 
 # For Confidential MintBurn
 spl-token-confidential-transfer-proof-extraction = { workspace = true }
-solana-zk-sdk = { workspace = true }

--- a/ingredients/mint_tokens/src/lib.rs
+++ b/ingredients/mint_tokens/src/lib.rs
@@ -1,19 +1,19 @@
 use std::error::Error;
 
-use utils::{get_or_create_keypair, get_rpc_client, print_transaction_url};
 use solana_sdk::{
     instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer,
     transaction::Transaction,
 };
+use utils::{get_or_create_keypair, get_rpc_client, print_transaction_url};
 //use solana_zk_sdk::encryption::pod::elgamal::PodElGamalCiphertext;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
-    //extension::confidential_mint_burn, 
-    instruction::mint_to, 
+    //extension::confidential_mint_burn,
+    instruction::mint_to,
     solana_zk_sdk::encryption::{
-        //auth_encryption::AeKey, 
-        elgamal::ElGamalKeypair
-    }
+        //auth_encryption::AeKey,
+        elgamal::ElGamalKeypair,
+    },
 };
 // use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
 
@@ -21,7 +21,7 @@ pub async fn go_with_confidential_mintburn(
     _mint_authority: &Keypair,
     _token_account_owner: &Pubkey,
     _mint_amount: u64,
-    _supply_elgamal_pubkey: &ElGamalKeypair
+    _supply_elgamal_pubkey: &ElGamalKeypair,
 ) -> Result<(), Box<dyn Error>> {
     Err("Not yet implemented".into())
 
@@ -38,7 +38,7 @@ pub async fn go_with_confidential_mintburn(
     // // Instruction to mint tokens
     // let context_state_dummy = Pubkey::new_unique();
 
-    // let confidential_mint_instructions = 
+    // let confidential_mint_instructions =
     //     confidential_mint_burn::instruction::confidential_mint_with_split_proofs(
     //         &spl_token_2022::id(),
     //         &receiving_token_account,
@@ -51,7 +51,7 @@ pub async fn go_with_confidential_mintburn(
     //         ProofLocation::ContextStateAccount(&context_state_dummy),
     //         ProofLocation::ContextStateAccount(&context_state_dummy),
     //         ProofLocation::ContextStateAccount(&context_state_dummy),
-    //         AeKey::new_rand().encrypt(mint_amount).into()            
+    //         AeKey::new_rand().encrypt(mint_amount).into()
     // )?;
 
     // let transaction = Transaction::new_signed_with_payer(
@@ -73,7 +73,7 @@ pub async fn go_with_confidential_mintburn(
 pub async fn go(
     mint_authority: &Keypair,
     token_account_owner: &Pubkey,
-    mint_amount: u64
+    mint_amount: u64,
 ) -> Result<(), Box<dyn Error>> {
     let client = get_rpc_client()?;
     let mint = get_or_create_keypair("mint")?;
@@ -81,7 +81,7 @@ pub async fn go(
 
     let receiving_token_account = get_associated_token_address_with_program_id(
         &token_account_owner, // Token account owner
-        &mint.pubkey(),        // Mint
+        &mint.pubkey(),       // Mint
         &spl_token_2022::id(),
     );
 
@@ -89,10 +89,10 @@ pub async fn go(
     let mint_to_instruction: Instruction = mint_to(
         &spl_token_2022::id(),
         &mint.pubkey(),              // Mint
-        &receiving_token_account,     // Token account to mint to
-        &mint_authority.pubkey(),         // Token account owner
+        &receiving_token_account,    // Token account to mint to
+        &mint_authority.pubkey(),    // Token account owner
         &[&mint_authority.pubkey()], // Additional signers (mint authority)
-        mint_amount,                      // Amount to mint
+        mint_amount,                 // Amount to mint
     )?;
 
     let transaction = Transaction::new_signed_with_payer(

--- a/ingredients/setup_mint/Cargo.toml
+++ b/ingredients/setup_mint/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 utils = { path = "../../utils" }
 solana-sdk = { workspace = true }
+solana-system-interface = "2.0.0"
 spl-token-2022 = { workspace = true }
 spl-token-client = { workspace = true }

--- a/ingredients/setup_mint/src/lib.rs
+++ b/ingredients/setup_mint/src/lib.rs
@@ -1,10 +1,19 @@
 use {
-    utils::{get_or_create_keypair, get_rpc_client, print_transaction_url, record_value}, solana_sdk::{
-        signature::Keypair, signer::Signer, system_instruction::create_account, transaction::Transaction
-    }, spl_token_2022::{extension::ExtensionType, instruction::initialize_mint, solana_zk_sdk::encryption::elgamal::ElGamalKeypair, state::Mint}, spl_token_client::token::ExtensionInitializationParams, std::{error::Error, sync::Arc}
+    solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction},
+    solana_system_interface::instruction::create_account,
+    spl_token_2022::{
+        extension::ExtensionType, instruction::initialize_mint,
+        solana_zk_sdk::encryption::elgamal::ElGamalKeypair, state::Mint,
+    },
+    spl_token_client::token::ExtensionInitializationParams,
+    std::{error::Error, sync::Arc},
+    utils::{get_or_create_keypair, get_rpc_client, print_transaction_url, record_value},
 };
 
-pub async fn create_mint(absolute_authority: &Keypair, auditor_elgamal_keypair: &ElGamalKeypair) -> Result<(), Box<dyn Error>> {
+pub async fn create_mint(
+    absolute_authority: &Keypair,
+    auditor_elgamal_keypair: &ElGamalKeypair,
+) -> Result<(), Box<dyn Error>> {
     let fee_payer_keypair = Arc::new(get_or_create_keypair("fee_payer_keypair")?);
     let client = get_rpc_client()?;
     let mint = get_or_create_keypair("mint")?;
@@ -45,10 +54,7 @@ pub async fn create_mint(absolute_authority: &Keypair, auditor_elgamal_keypair: 
     let extension_instruction =
         confidential_transfer_mint_extension.instruction(&spl_token_2022::id(), &mint.pubkey())?;
 
-    let instructions = vec![
-        create_account_instruction,
-        extension_instruction,
-    ];
+    let instructions = vec![create_account_instruction, extension_instruction];
 
     let recent_blockhash = client.get_latest_blockhash()?;
     let transaction = Transaction::new_signed_with_payer(
@@ -58,7 +64,8 @@ pub async fn create_mint(absolute_authority: &Keypair, auditor_elgamal_keypair: 
         recent_blockhash,
     );
 
-    { // Add `initialize_mint_instruction` to the signed transaction
+    {
+        // Add `initialize_mint_instruction` to the signed transaction
 
         let mut transaction = transaction;
 
@@ -73,24 +80,29 @@ pub async fn create_mint(absolute_authority: &Keypair, auditor_elgamal_keypair: 
         )?;
 
         {
-            let mut unique_pubkeys: std::collections::HashSet<_> = transaction.message.account_keys.iter().cloned().collect();
+            let mut unique_pubkeys: std::collections::HashSet<_> =
+                transaction.message.account_keys.iter().cloned().collect();
             transaction.message.account_keys.extend(
                 initialize_mint_instruction
                     .accounts
                     .iter()
                     .map(|account| account.pubkey)
-                    .filter(|pubkey| unique_pubkeys.insert(*pubkey))
+                    .filter(|pubkey| unique_pubkeys.insert(*pubkey)),
             );
         }
 
-        let compiled_initialize_mint_instruction = 
-            transaction.message.compile_instruction(&initialize_mint_instruction);
-        
-        transaction.message.instructions.push(compiled_initialize_mint_instruction);
+        let compiled_initialize_mint_instruction = transaction
+            .message
+            .compile_instruction(&initialize_mint_instruction);
+
+        transaction
+            .message
+            .instructions
+            .push(compiled_initialize_mint_instruction);
 
         transaction.sign(
             &[&fee_payer_keypair, &mint as &dyn Signer],
-            recent_blockhash
+            recent_blockhash,
         );
 
         let transaction_signature = client.send_and_confirm_transaction(&transaction)?;

--- a/ingredients/setup_mint_confidential/Cargo.toml
+++ b/ingredients/setup_mint_confidential/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 utils = { path = "../../utils" }
 solana-sdk = { workspace = true }
+solana-system-interface = "2.0.0"
 spl-token-2022 = { workspace = true }
 spl-token-client = { workspace = true }

--- a/ingredients/setup_mint_confidential/src/lib.rs
+++ b/ingredients/setup_mint_confidential/src/lib.rs
@@ -1,22 +1,23 @@
 use {
-    utils::{get_or_create_keypair, get_rpc_client, record_value},
-    solana_sdk::{
-        signature::Keypair, signer::Signer, system_instruction::create_account,
-        transaction::Transaction,
-    },
+    solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction},
+    solana_system_interface::instruction::create_account,
     spl_token_2022::{
-        extension::{confidential_mint_burn, ExtensionType}, instruction::initialize_mint,
-        solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair, pod::elgamal::PodElGamalPubkey}, state::Mint,
+        extension::{confidential_mint_burn, ExtensionType},
+        instruction::initialize_mint,
+        solana_zk_sdk::encryption::{
+            auth_encryption::AeKey, elgamal::ElGamalKeypair, pod::elgamal::PodElGamalPubkey,
+        },
+        state::Mint,
     },
     spl_token_client::token::ExtensionInitializationParams,
     std::{error::Error, sync::Arc},
+    utils::{get_or_create_keypair, get_rpc_client, record_value},
 };
 
 pub async fn create_mint(
     absolute_authority: &Keypair,
     auditor_elgamal_keypair: &ElGamalKeypair,
 ) -> Result<(), Box<dyn Error>> {
-     
     let fee_payer_keypair = Arc::new(get_or_create_keypair("fee_payer_keypair")?);
     let client = get_rpc_client()?;
     let mint = get_or_create_keypair("mint")?;
@@ -45,18 +46,19 @@ pub async fn create_mint(
         space as u64,
         &spl_token_2022::id(),
     );
-        
+
     // ConfidentialTransferMint extension instruction
     let extension_confidential_transfer_init_instruction =
-    ExtensionInitializationParams::ConfidentialTransferMint {
-        authority: Some(authority.pubkey()),
-        auto_approve_new_accounts: true, // If `true`, no approval is required and new accounts may be used immediately
-        auditor_elgamal_pubkey: Some((*auditor_elgamal_keypair.pubkey()).into()),
-    }
-    .instruction(&spl_token_2022::id(), &mint.pubkey())?;
+        ExtensionInitializationParams::ConfidentialTransferMint {
+            authority: Some(authority.pubkey()),
+            auto_approve_new_accounts: true, // If `true`, no approval is required and new accounts may be used immediately
+            auditor_elgamal_pubkey: Some((*auditor_elgamal_keypair.pubkey()).into()),
+        }
+        .instruction(&spl_token_2022::id(), &mint.pubkey())?;
 
-    let pod_auditor_elgamal_keypair: PodElGamalPubkey = auditor_elgamal_keypair.pubkey_owned().into();
-    let extension_mintburn_init_instruction= confidential_mint_burn::instruction::initialize_mint(
+    let pod_auditor_elgamal_keypair: PodElGamalPubkey =
+        auditor_elgamal_keypair.pubkey_owned().into();
+    let extension_mintburn_init_instruction = confidential_mint_burn::instruction::initialize_mint(
         &spl_token_2022::id(),
         &mint.pubkey(),
         &pod_auditor_elgamal_keypair,
@@ -93,6 +95,6 @@ pub async fn create_mint(
         "\nCreate Mint Account: https://explorer.solana.com/tx/{}?cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899",
         transaction_signature
     );
-    
+
     Ok(())
 }

--- a/ingredients/setup_participants/Cargo.toml
+++ b/ingredients/setup_participants/Cargo.toml
@@ -11,3 +11,4 @@ path = "src/lib.rs"
 utils = { path = "../../utils" }
 tokio = { workspace = true }
 solana-sdk = { workspace = true }
+solana-system-interface = "2.0.0"

--- a/ingredients/setup_participants/src/lib.rs
+++ b/ingredients/setup_participants/src/lib.rs
@@ -1,30 +1,42 @@
 use utils::get_rpc_client;
 use {
-    solana_sdk::{
-        pubkey::Pubkey, signature::Keypair
-    },
+    solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction},
+    solana_system_interface::instruction as system_instruction,
     std::error::Error,
 };
 
-pub async fn setup_basic_participant(participant_pubkey: &Pubkey, fee_payer_keypair: Option<&Keypair>, initial_lamports: u64) -> Result<(), Box<dyn Error>> {
-
+pub async fn setup_basic_participant(
+    participant_pubkey: &Pubkey,
+    fee_payer_keypair: Option<&Keypair>,
+    initial_lamports: u64,
+) -> Result<(), Box<dyn Error>> {
     let client = get_rpc_client()?;
 
     match fee_payer_keypair {
         Some(keypair) => {
             let recent_blockhash = client.get_latest_blockhash()?;
-            let tx = solana_sdk::system_transaction::transfer(
-                keypair,
+            let ix = system_instruction::transfer(
+                &keypair.pubkey(),
                 participant_pubkey,
                 initial_lamports,
+            );
+            let tx = Transaction::new_signed_with_payer(
+                &[ix],
+                Some(&keypair.pubkey()),
+                &[keypair],
                 recent_blockhash,
             );
             client.send_and_confirm_transaction(&tx)?;
         }
         None => {
-            if client.request_airdrop(&participant_pubkey, initial_lamports).is_err() {
+            if client
+                .request_airdrop(&participant_pubkey, initial_lamports)
+                .is_err()
+            {
                 let current_balance = client.get_balance(&participant_pubkey)?;
-                println!("Failed to request airdrop. Ensure the fee payer account has sufficient SOL.");
+                println!(
+                    "Failed to request airdrop. Ensure the fee payer account has sufficient SOL."
+                );
                 println!("Current participant balance: {}", current_balance);
             }
         }
@@ -39,9 +51,9 @@ pub async fn setup_basic_participant(participant_pubkey: &Pubkey, fee_payer_keyp
 #[cfg(test)]
 mod tests {
     use super::*;
-    use utils::get_or_create_keypair;
-    use solana_sdk::signer::Signer;
     use solana_sdk::native_token::LAMPORTS_PER_SOL;
+    use solana_sdk::signer::Signer;
+    use utils::get_or_create_keypair;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_setup_basic_participant() -> Result<(), Box<dyn Error>> {

--- a/ingredients/setup_token_account/src/lib.rs
+++ b/ingredients/setup_token_account/src/lib.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 
-use utils::{get_or_create_keypair, get_rpc_client, print_transaction_url};
 use solana_sdk::{signer::Signer, transaction::Transaction};
 use spl_associated_token_account::{
     get_associated_token_address_with_program_id, instruction::create_associated_token_account,
@@ -14,12 +13,12 @@ use spl_token_2022::{
     instruction::reallocate,
     solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
 };
-use spl_token_confidential_transfer_proof_extraction::instruction::{ProofData, ProofLocation};
+use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
+use utils::{get_or_create_keypair, get_rpc_client, print_transaction_url};
 
 pub async fn setup_token_account(
-    token_account_authority: &dyn Signer
+    token_account_authority: &dyn Signer,
 ) -> Result<(), Box<dyn Error>> {
-
     let client = get_rpc_client()?;
     let mint = get_or_create_keypair("mint")?;
     let fee_payer_keypair = get_or_create_keypair("fee_payer_keypair")?;
@@ -71,21 +70,18 @@ pub async fn setup_token_account(
 
     // `InstructionOffset` indicates that proof is included in the same transaction
     // This means that the proof instruction offset must be always be 1.
-    let proof_location = ProofLocation::InstructionOffset(
-        1.try_into().unwrap(),
-        ProofData::InstructionData(&proof_data),
-    );
+    let proof_location = ProofLocation::InstructionOffset(1.try_into().unwrap(), &proof_data);
 
     // Instructions to configure the token account, including the proof instruction
     // Appends the `VerifyPubkeyValidityProof` instruction right after the `ConfigureAccount` instruction.
     let configure_account_instruction = configure_account(
-        &spl_token_2022::id(),                 // Program ID
-        &token_account_pubkey,                 // Token account
-        &mint.pubkey(),                        // Mint
-        &decryptable_balance.into(),             // Initial balance
+        &spl_token_2022::id(),                  // Program ID
+        &token_account_pubkey,                  // Token account
+        &mint.pubkey(),                         // Mint
+        &decryptable_balance.into(),            // Initial balance
         maximum_pending_balance_credit_counter, // Maximum pending balance credit counter
-        &token_account_authority.pubkey(),     // Token Account Owner
-        &[],                                   // Additional signers
+        &token_account_authority.pubkey(),      // Token Account Owner
+        &[],                                    // Additional signers
         proof_location,                         // Proof location
     )
     .unwrap();

--- a/ingredients/transfer/Cargo.toml
+++ b/ingredients/transfer/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2021"
 
 [dependencies]
 solana-sdk = { workspace = true }
+solana-client = { workspace = true }
+solana-system-interface = "2.0.0"
 spl-token-client = { workspace = true }
 spl-token-2022 = { workspace = true }
 spl-associated-token-account = { workspace = true }
 spl-token-confidential-transfer-proof-generation = { workspace = true }
 spl-token-confidential-transfer-proof-extraction = { workspace = true }
-solana-zk-sdk = { workspace = true }
 
 bs58 = { workspace = true }
 jito-sdk-rust = { workspace = true }

--- a/ingredients/transfer/src/lib.rs
+++ b/ingredients/transfer/src/lib.rs
@@ -1,17 +1,17 @@
 use {
-    utils::{
-        get_non_blocking_rpc_client, get_or_create_keypair, get_rpc_client, jito, load_value, print_transaction_url, record_value
-    },
     serde_json::json,
     solana_sdk::{
-        pubkey::Pubkey, signature::{Keypair, Signer}, system_instruction, transaction::Transaction
+        pubkey::Pubkey,
+        signature::{Keypair, Signature, Signer},
+        transaction::Transaction,
     },
+    solana_system_interface::instruction as system_instruction,
     spl_associated_token_account::get_associated_token_address_with_program_id,
     spl_token_2022::{
         extension::{
             confidential_transfer::{
-                account_info::TransferAccountInfo,
-                ConfidentialTransferAccount, ConfidentialTransferMint,
+                account_info::TransferAccountInfo, ConfidentialTransferAccount,
+                ConfidentialTransferMint,
             },
             BaseStateWithExtensions, StateWithExtensionsOwned,
         },
@@ -21,38 +21,189 @@ use {
                 elgamal::{self, ElGamalKeypair},
                 pod::elgamal::PodElGamalPubkey,
             },
-            zk_elgamal_proof_program::{self, instruction::{close_context_state, ContextStateInfo}},
+            zk_elgamal_proof_program::{
+                self,
+                instruction::{close_context_state, ContextStateInfo},
+            },
         },
         state::{Account, Mint},
     },
     spl_token_client::{
         client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-        token::{ProofAccount, ProofAccountWithCiphertext, Token},
+        token::{ProofAccountWithCiphertext, Token},
     },
     spl_token_confidential_transfer_proof_generation::transfer::TransferProofData,
-    std::{error::Error, sync::Arc}
+    std::{error::Error, sync::Arc},
+    utils::{
+        get_non_blocking_rpc_client, get_or_create_keypair, get_rpc_client, jito, load_value,
+        print_transaction_url, record_value,
+    },
 };
 
-pub async fn with_split_proofs(sender_keypair: Arc<dyn Signer>, recipient_keypair: Arc<dyn Signer>, confidential_transfer_amount: u64) -> Result<(), Box<dyn Error>> {   
-
-    let client = get_rpc_client()?;
-    let transactions = prepare_transactions(sender_keypair.clone(), recipient_keypair, confidential_transfer_amount).await?;
-    assert!(transactions.len() == 5);
-
-    print_transaction_url("Transfer [Allocate Proof Accounts]", &client.send_and_confirm_transaction(&transactions[0])?.to_string());
-    print_transaction_url("Transfer [Encode Range Proof]", &client.send_and_confirm_transaction(&transactions[1])?.to_string());
-    print_transaction_url("Transfer [Encode Remaining Proofs]", &client.send_and_confirm_transaction(&transactions[2])?.to_string());
-    let transfer_signature = client.send_and_confirm_transaction(&transactions[3])?;
-    print_transaction_url("Transfer [Execute Transfer]", &transfer_signature.to_string());
-    print_transaction_url("Transfer [Close Proof Accounts]", &client.send_and_confirm_transaction(&transactions[4])?.to_string());
-
-    record_value("last_confidential_transfer_signature", &transfer_signature.to_string())?;
-
-    Ok(())
-
+struct TransferContext {
+    equality_proof_pubkey: Pubkey,
+    ciphertext_validity_proof_pubkey: Pubkey,
+    range_proof_pubkey: Pubkey,
+    ciphertext_validity_proof_account_with_ciphertext: ProofAccountWithCiphertext,
+    sender_associated_token_address: Pubkey,
+    recipient_associated_token_address: Pubkey,
+    sender_transfer_account_info: TransferAccountInfo,
+    sender_elgamal_keypair: ElGamalKeypair,
+    sender_aes_key: AeKey,
+    recipient_elgamal_pubkey: elgamal::ElGamalPubkey,
+    auditor_elgamal_pubkey: elgamal::ElGamalPubkey,
 }
 
-async fn prepare_transactions(sender_keypair: Arc<dyn Signer>, recipient_keypair: Arc<dyn Signer>, confidential_transfer_amount: u64) -> Result<Vec<Transaction>, Box<dyn Error>> {
+pub async fn with_split_proofs(
+    sender_keypair: Arc<dyn Signer>,
+    recipient_keypair: Arc<dyn Signer>,
+    confidential_transfer_amount: u64,
+) -> Result<(), Box<dyn Error>> {
+    let client = get_rpc_client()?;
+    let (transactions, ctx) = prepare_proof_transactions(
+        sender_keypair.clone(),
+        recipient_keypair,
+        confidential_transfer_amount,
+    )
+    .await?;
+
+    print_transaction_url(
+        "Transfer [Allocate Proof Accounts]",
+        &client
+            .send_and_confirm_transaction(&transactions[0])?
+            .to_string(),
+    );
+    print_transaction_url(
+        "Transfer [Encode Range Proof]",
+        &client
+            .send_and_confirm_transaction(&transactions[1])?
+            .to_string(),
+    );
+    print_transaction_url(
+        "Transfer [Encode Remaining Proofs]",
+        &client
+            .send_and_confirm_transaction(&transactions[2])?
+            .to_string(),
+    );
+
+    let transfer_signature =
+        execute_transfer(sender_keypair.clone(), &ctx, confidential_transfer_amount).await?;
+    print_transaction_url(
+        "Transfer [Execute Transfer]",
+        &transfer_signature.to_string(),
+    );
+
+    let close_tx = build_close_proof_accounts_tx(sender_keypair.clone(), &ctx, &client)?;
+    print_transaction_url(
+        "Transfer [Close Proof Accounts]",
+        &client.send_and_confirm_transaction(&close_tx)?.to_string(),
+    );
+
+    record_value(
+        "last_confidential_transfer_signature",
+        &transfer_signature.to_string(),
+    )?;
+
+    Ok(())
+}
+
+async fn execute_transfer(
+    sender_keypair: Arc<dyn Signer>,
+    ctx: &TransferContext,
+    confidential_transfer_amount: u64,
+) -> Result<Signature, Box<dyn Error>> {
+    let mint = get_or_create_keypair("mint")?;
+    let decimals = load_value("mint_decimals")?;
+
+    let token = {
+        let rpc_client = get_non_blocking_rpc_client()?;
+        let program_client: ProgramRpcClient<ProgramRpcClientSendTransaction> =
+            ProgramRpcClient::new(Arc::new(rpc_client), ProgramRpcClientSendTransaction);
+        Token::new(
+            Arc::new(program_client),
+            &spl_token_2022::id(),
+            &mint.pubkey(),
+            Some(decimals),
+            sender_keypair.clone(),
+        )
+    };
+
+    let response = token
+        .confidential_transfer_transfer(
+            &ctx.sender_associated_token_address,
+            &ctx.recipient_associated_token_address,
+            &sender_keypair.pubkey(),
+            Some(&ctx.equality_proof_pubkey),
+            Some(&ctx.ciphertext_validity_proof_account_with_ciphertext),
+            Some(&ctx.range_proof_pubkey),
+            confidential_transfer_amount,
+            Some(ctx.sender_transfer_account_info.clone()),
+            &ctx.sender_elgamal_keypair,
+            &ctx.sender_aes_key,
+            &ctx.recipient_elgamal_pubkey,
+            Some(&ctx.auditor_elgamal_pubkey),
+            &[&sender_keypair],
+        )
+        .await?;
+
+    match response {
+        spl_token_client::client::RpcClientResponse::Signature(sig) => Ok(sig),
+        _ => Err("Expected signature response from transfer".into()),
+    }
+}
+
+fn build_close_proof_accounts_tx(
+    sender_keypair: Arc<dyn Signer>,
+    ctx: &TransferContext,
+    client: &solana_client::rpc_client::RpcClient,
+) -> Result<Transaction, Box<dyn Error>> {
+    let context_state_authority_pubkey = sender_keypair.pubkey();
+    let destination_account = &sender_keypair.pubkey();
+
+    let close_equality_proof_instruction = close_context_state(
+        ContextStateInfo {
+            context_state_account: &ctx.equality_proof_pubkey,
+            context_state_authority: &context_state_authority_pubkey,
+        },
+        &destination_account,
+    );
+
+    let close_ciphertext_validity_proof_instruction = close_context_state(
+        ContextStateInfo {
+            context_state_account: &ctx.ciphertext_validity_proof_pubkey,
+            context_state_authority: &context_state_authority_pubkey,
+        },
+        &destination_account,
+    );
+
+    let close_range_proof_instruction = close_context_state(
+        ContextStateInfo {
+            context_state_account: &ctx.range_proof_pubkey,
+            context_state_authority: &context_state_authority_pubkey,
+        },
+        &destination_account,
+    );
+
+    let recent_blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            close_equality_proof_instruction,
+            close_ciphertext_validity_proof_instruction,
+            close_range_proof_instruction,
+        ],
+        Some(&sender_keypair.pubkey()),
+        &[&sender_keypair],
+        recent_blockhash,
+    );
+
+    Ok(tx)
+}
+
+async fn prepare_proof_transactions(
+    sender_keypair: Arc<dyn Signer>,
+    recipient_keypair: Arc<dyn Signer>,
+    confidential_transfer_amount: u64,
+) -> Result<(Vec<Transaction>, TransferContext), Box<dyn Error>> {
     let client = get_rpc_client()?;
 
     let mint = get_or_create_keypair("mint")?;
@@ -69,26 +220,12 @@ async fn prepare_transactions(sender_keypair: Arc<dyn Signer>, recipient_keypair
         let program_client: ProgramRpcClient<ProgramRpcClientSendTransaction> =
             ProgramRpcClient::new(Arc::new(rpc_client), ProgramRpcClientSendTransaction);
 
-        // Create a "token" client, to use various helper functions for Token Extensions
         Token::new(
             Arc::new(program_client),
             &spl_token_2022::id(),
             &mint.pubkey(),
             Some(decimals),
             sender_keypair.clone(),
-            /*
-            Can't use the intended separate fee_payer_keypair because I get the following error:
-            Client(Error { 
-                request: Some(SendTransaction), 
-                kind: RpcError(RpcResponseError { 
-                    code: -32602, 
-                    message: "base64 encoded solana_sdk::transaction::versioned::VersionedTransaction too large: 1652 bytes (max: encoded/raw 1644/1232)", 
-                    data: Empty 
-                }) 
-            })
-
-            Makes me wonder if transaction has one too many signers for range proof.
-            */
         )
     };
     let recipient_associated_token_address = get_associated_token_address_with_program_id(
@@ -97,29 +234,17 @@ async fn prepare_transactions(sender_keypair: Arc<dyn Signer>, recipient_keypair
         &spl_token_2022::id(),
     );
 
-    // Must first create 3 accounts to store proofs before transferring tokens
-    // This must be done in a separate transactions because the proofs are too large for single transaction
-
-    // Equality Proof - prove that two ciphertexts encrypt the same value
-    // Ciphertext Validity Proof - prove that ciphertexts are properly generated
-    // Range Proof - prove that ciphertexts encrypt a value in a specified range (0, u64::MAX)
-
-    // "Authority" for the proof accounts (to close the accounts after the transfer)
     let context_state_authority = &sender_keypair;
 
-    // Generate address for equality proof account
     let equality_proof_context_state_account = Keypair::new();
     let equality_proof_pubkey = equality_proof_context_state_account.pubkey();
 
-    // Generate address for ciphertext validity proof account
     let ciphertext_validity_proof_context_state_account = Keypair::new();
     let ciphertext_validity_proof_pubkey = ciphertext_validity_proof_context_state_account.pubkey();
 
-    // Generate address for range proof account
     let range_proof_context_state_account = Keypair::new();
     let range_proof_pubkey = range_proof_context_state_account.pubkey();
 
-    // Get sender token account data
     let sender_token_account_info = token
         .get_account_info(&sender_associated_token_address)
         .await?;
@@ -127,42 +252,37 @@ async fn prepare_transactions(sender_keypair: Arc<dyn Signer>, recipient_keypair
     let sender_account_extension_data =
         sender_token_account_info.get_extension::<ConfidentialTransferAccount>()?;
 
-    // ConfidentialTransferAccount extension information needed to create proof data
     let sender_transfer_account_info = TransferAccountInfo::new(sender_account_extension_data);
 
-    let sender_elgamal_keypair =
-        ElGamalKeypair::new_from_signer(&sender_keypair, &sender_associated_token_address.to_bytes())?;
+    let sender_elgamal_keypair = ElGamalKeypair::new_from_signer(
+        &sender_keypair,
+        &sender_associated_token_address.to_bytes(),
+    )?;
     let sender_aes_key =
         AeKey::new_from_signer(&sender_keypair, &sender_associated_token_address.to_bytes())?;
 
-    // Get recipient token account data
     let recipient_account = token
         .get_account(recipient_associated_token_address)
         .await?;
 
-    // Get recipient ElGamal pubkey from the recipient token account data and convert to elgamal::ElGamalPubkey
     let recipient_elgamal_pubkey: elgamal::ElGamalPubkey =
         StateWithExtensionsOwned::<Account>::unpack(recipient_account.data)?
             .get_extension::<ConfidentialTransferAccount>()?
             .elgamal_pubkey
             .try_into()?;
 
-    // Get mint account data
     let mint_account = token.get_account(mint.pubkey()).await?;
 
-    // Get auditor ElGamal pubkey from the mint account data
     let auditor_elgamal_pubkey_option = Option::<PodElGamalPubkey>::from(
         StateWithExtensionsOwned::<Mint>::unpack(mint_account.data)?
             .get_extension::<ConfidentialTransferMint>()?
             .auditor_elgamal_pubkey,
     );
 
-    // Convert auditor ElGamal pubkey to elgamal::ElGamalPubkey type
     let auditor_elgamal_pubkey: elgamal::ElGamalPubkey = auditor_elgamal_pubkey_option
         .ok_or("No Auditor ElGamal pubkey")?
         .try_into()?;
 
-    // Generate proof data
     let TransferProofData {
         equality_proof_data,
         ciphertext_validity_proof_data_with_ciphertext,
@@ -175,25 +295,22 @@ async fn prepare_transactions(sender_keypair: Arc<dyn Signer>, recipient_keypair
         Some(&auditor_elgamal_pubkey),
     )?;
 
-    // Create 3 proofs ------------------------------------------------------
+    let (range_create_ix, range_verify_ix) =
+        get_zk_proof_context_state_account_creation_instructions(
+            &sender_keypair.pubkey(),
+            &range_proof_context_state_account.pubkey(),
+            &context_state_authority.pubkey(),
+            &range_proof_data,
+        )?;
 
-    // Range Proof Instructions------------------------------------------------------------------------------
-    let (range_create_ix, range_verify_ix) = get_zk_proof_context_state_account_creation_instructions(
-        &sender_keypair.pubkey(),
-        &range_proof_context_state_account.pubkey(),
-        &context_state_authority.pubkey(),
-        &range_proof_data,
-    )?;
+    let (equality_create_ix, equality_verify_ix) =
+        get_zk_proof_context_state_account_creation_instructions(
+            &sender_keypair.pubkey(),
+            &equality_proof_context_state_account.pubkey(),
+            &context_state_authority.pubkey(),
+            &equality_proof_data,
+        )?;
 
-    // Equality Proof Instructions---------------------------------------------------------------------------
-    let (equality_create_ix, equality_verify_ix) = get_zk_proof_context_state_account_creation_instructions(
-        &sender_keypair.pubkey(),
-        &equality_proof_context_state_account.pubkey(),
-        &context_state_authority.pubkey(),
-        &equality_proof_data,
-    )?;
-
-    // Ciphertext Validity Proof Instructions ----------------------------------------------------------------
     let (cv_create_ix, cv_verify_ix) = get_zk_proof_context_state_account_creation_instructions(
         &sender_keypair.pubkey(),
         &ciphertext_validity_proof_context_state_account.pubkey(),
@@ -201,23 +318,22 @@ async fn prepare_transactions(sender_keypair: Arc<dyn Signer>, recipient_keypair
         &ciphertext_validity_proof_data_with_ciphertext.proof_data,
     )?;
 
-
-    // Transact Proofs ------------------------------------------------------------------------------------
-    
-    // Transaction 1: Allocate all proof accounts at once.
     let tx1 = Transaction::new_signed_with_payer(
-        &[range_create_ix.clone(), equality_create_ix.clone(), cv_create_ix.clone()],
+        &[
+            range_create_ix.clone(),
+            equality_create_ix.clone(),
+            cv_create_ix.clone(),
+        ],
         Some(&sender_keypair.pubkey()),
         &[
-            &sender_keypair, 
-            &range_proof_context_state_account as &dyn Signer, 
-            &equality_proof_context_state_account as &dyn Signer, 
-            &ciphertext_validity_proof_context_state_account as &dyn Signer
+            &sender_keypair,
+            &range_proof_context_state_account as &dyn Signer,
+            &equality_proof_context_state_account as &dyn Signer,
+            &ciphertext_validity_proof_context_state_account as &dyn Signer,
         ],
         client.get_latest_blockhash()?,
     );
-    
-    // Transaction 2: Encode Range Proof on its own (because it's the largest).
+
     let tx2 = Transaction::new_signed_with_payer(
         &[range_verify_ix],
         Some(&sender_keypair.pubkey()),
@@ -225,152 +341,94 @@ async fn prepare_transactions(sender_keypair: Arc<dyn Signer>, recipient_keypair
         client.get_latest_blockhash()?,
     );
 
-    // Transaction 3: Encode all remaining proofs.
     let tx3 = Transaction::new_signed_with_payer(
         &[equality_verify_ix, cv_verify_ix],
         Some(&sender_keypair.pubkey()),
         &[&sender_keypair],
         client.get_latest_blockhash()?,
     );
-    
-    // Transaction 4: Execute transfer (below)
-    // Transfer with Split Proofs -------------------------------------------
-
-    let equality_proof_context_proof_account = ProofAccount::ContextAccount(equality_proof_pubkey);
-    let ciphertext_validity_proof_context_proof_account =
-        ProofAccount::ContextAccount(ciphertext_validity_proof_pubkey);
-    let range_proof_context_proof_account = ProofAccount::ContextAccount(range_proof_pubkey);
 
     let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
-        proof_account: ciphertext_validity_proof_context_proof_account,
+        context_state_account: ciphertext_validity_proof_pubkey,
         ciphertext_lo: ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo,
         ciphertext_hi: ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi,
     };
 
-    let tx4 = token.confidential_transfer_transfer_tx(
-        &sender_associated_token_address,
-        &recipient_associated_token_address,
-        &sender_keypair.pubkey(),
-        Some(&equality_proof_context_proof_account),
-        Some(&ciphertext_validity_proof_account_with_ciphertext),
-        Some(&range_proof_context_proof_account),
-        confidential_transfer_amount,
-        Some(sender_transfer_account_info),
-        &sender_elgamal_keypair,
-        &sender_aes_key,
-        &recipient_elgamal_pubkey,
-        Some(&auditor_elgamal_pubkey),
-        &[&sender_keypair],
-    ).await?;
+    let ctx = TransferContext {
+        equality_proof_pubkey,
+        ciphertext_validity_proof_pubkey,
+        range_proof_pubkey,
+        ciphertext_validity_proof_account_with_ciphertext,
+        sender_associated_token_address,
+        recipient_associated_token_address,
+        sender_transfer_account_info,
+        sender_elgamal_keypair,
+        sender_aes_key,
+        recipient_elgamal_pubkey,
+        auditor_elgamal_pubkey,
+    };
 
-    // Transaction 5: (below)
-    // Close Proof Accounts --------------------------------------------------
-
-    // Authority to close the proof accounts
-    let context_state_authority_pubkey = context_state_authority.pubkey();
-    // Lamports from the closed proof accounts will be sent to this account
-    let destination_account = &sender_keypair.pubkey();
-
-    // Close the equality proof account
-    let close_equality_proof_instruction = close_context_state(
-        ContextStateInfo {
-            context_state_account: &equality_proof_pubkey,
-            context_state_authority: &context_state_authority_pubkey,
-        },
-        &destination_account,
-    );
-
-    // Close the ciphertext validity proof account
-    let close_ciphertext_validity_proof_instruction = close_context_state(
-        ContextStateInfo {
-            context_state_account: &ciphertext_validity_proof_pubkey,
-            context_state_authority: &context_state_authority_pubkey,
-        },
-        &destination_account,
-    );
-
-    // Close the range proof account
-    let close_range_proof_instruction = close_context_state(
-        ContextStateInfo {
-            context_state_account: &range_proof_pubkey,
-            context_state_authority: &context_state_authority_pubkey,
-        },
-        &destination_account,
-    );
-
-    let recent_blockhash = client.get_latest_blockhash()?;
-    let tx5 = Transaction::new_signed_with_payer(
-        &[
-            close_equality_proof_instruction,
-            close_ciphertext_validity_proof_instruction,
-            close_range_proof_instruction,
-        ],
-        Some(&sender_keypair.pubkey()),
-        &[&sender_keypair], // Signers
-        recent_blockhash,
-    );
-
-    Ok(vec![tx1, tx2, tx3, tx4, tx5])
+    Ok((vec![tx1, tx2, tx3], ctx))
 }
 
-pub async fn with_split_proofs_atomic(sender_keypair: Arc<dyn Signer>, recipient_keypair: Arc<dyn Signer>, confidential_transfer_amount: u64) -> Result<(), Box<dyn Error>> {
-    
-    // When using Jito bundles there are many reasons why a bundle might not land:
-    // - Not enough priority fee prolongs transaction inclusion, risking rejection.
-    //   - Unfortunately, many transactions in transfer are saturated, lacking room to insert a priority fee instruction.
-    //   - This is the most likely reason why bundles fail.
-    // - We never know if the leading validator is running the Jito engine.
-
-    // We'll do a best attempt at retrying the bundle.
+pub async fn with_split_proofs_atomic(
+    sender_keypair: Arc<dyn Signer>,
+    recipient_keypair: Arc<dyn Signer>,
+    confidential_transfer_amount: u64,
+) -> Result<(), Box<dyn Error>> {
     utils::run_with_retry(5, || async {
+        let client = get_rpc_client()?;
+        let (mut transactions, ctx) = prepare_proof_transactions(
+            sender_keypair.clone(),
+            recipient_keypair.clone(),
+            confidential_transfer_amount,
+        )
+        .await?;
 
-        let mut transactions = prepare_transactions(sender_keypair.clone(), recipient_keypair.clone(), confidential_transfer_amount).await?;
+        assert!(
+            client.url().contains("testnet") || client.url().contains("mainnet"),
+            "This Jito demo only works on testnet or mainnet (adjust code for custom endpoints)"
+        );
 
-        // Reconstruct the one transaction to add the jito tip instruction.
+        let jito_tip_ix = jito::create_jito_tip_instruction(sender_keypair.pubkey()).await?;
+
+        let tx3 = &mut transactions[2];
         {
-            // Not-so-early-out check for testnet or mainnet.
-            let client = get_rpc_client()?;
-            assert!(client.url().contains("testnet") || client.url().contains("mainnet"), "This Jito demo only works on testnet or mainnet (adjust code for custom endpoints)");
-            
-            let jito_tip_ix = jito::create_jito_tip_instruction(sender_keypair.pubkey()).await?;
-            
-            // Any transaction can be used. This one is the simplest to edit (and fits within size limits).
-            let tx3 = &mut transactions[2];
+            let mut unique_pubkeys: std::collections::HashSet<_> =
+                tx3.message.account_keys.iter().cloned().collect();
+            tx3.message.account_keys.extend(
+                jito_tip_ix
+                    .accounts
+                    .iter()
+                    .map(|account| account.pubkey)
+                    .filter(|pubkey| unique_pubkeys.insert(*pubkey)),
+            );
 
-            // Include instruction's accounts into the transaction (without duplicates).
-            {
-                let mut unique_pubkeys: std::collections::HashSet<_> = tx3.message.account_keys.iter().cloned().collect();
-                tx3.message.account_keys.extend(
-                    jito_tip_ix
-                        .accounts
-                        .iter()
-                        .map(|account| account.pubkey)
-                        .filter(|pubkey| unique_pubkeys.insert(*pubkey))
-                );
-
-                tx3.message.account_keys.push(solana_sdk::system_program::id());
-            }
-            
-            // Include instruction into the transaction.
-            let compiled_jito_tip_ix = tx3.message.compile_instruction(&jito_tip_ix);
-            tx3.message.instructions.push(compiled_jito_tip_ix);
-
-            // Re-sign the transaction for integrity.
-            tx3.sign(&[&sender_keypair], client.get_latest_blockhash()?);
-
+            tx3.message
+                .account_keys
+                .push(solana_system_interface::program::id());
         }
+
+        let compiled_jito_tip_ix = tx3.message.compile_instruction(&jito_tip_ix);
+        tx3.message.instructions.push(compiled_jito_tip_ix);
+        tx3.sign(&[&sender_keypair], client.get_latest_blockhash()?);
+
+        let transfer_signature =
+            execute_transfer(sender_keypair.clone(), &ctx, confidential_transfer_amount).await?;
+
+        let close_tx = build_close_proof_accounts_tx(sender_keypair.clone(), &ctx, &client)?;
 
         let serialized_tx1 = bs58::encode(bincode::serialize(&transactions[0])?).into_string();
         let serialized_tx2 = bs58::encode(bincode::serialize(&transactions[1])?).into_string();
         let serialized_tx3 = bs58::encode(bincode::serialize(&transactions[2])?).into_string();
-        let serialized_tx4 = bs58::encode(bincode::serialize(&transactions[3])?).into_string();
-        let serialized_tx5 = bs58::encode(bincode::serialize(&transactions[4])?).into_string();
-        
+        let serialized_tx4 = bs58::encode(transfer_signature.as_ref()).into_string();
+        let serialized_tx5 = bs58::encode(bincode::serialize(&close_tx)?).into_string();
+
         let tx_bundle = json!([
-            serialized_tx1, 
-            serialized_tx2, 
-            serialized_tx3, 
-            serialized_tx4, 
+            serialized_tx1,
+            serialized_tx2,
+            serialized_tx3,
+            serialized_tx4,
             serialized_tx5
         ]);
 
@@ -380,15 +438,17 @@ pub async fn with_split_proofs_atomic(sender_keypair: Arc<dyn Signer>, recipient
         print_transaction_url("Transfer [Encode Remaining Proofs]", &bundled_signatures[2]);
         print_transaction_url("Transfer [Execute Transfer]", &bundled_signatures[3]);
         print_transaction_url("Transfer [Close Proof Accounts]", &bundled_signatures[4]);
-        
-        record_value("last_confidential_transfer_signature", &bundled_signatures[3])?;
-    
+
+        record_value(
+            "last_confidential_transfer_signature",
+            &bundled_signatures[3],
+        )?;
+
         Ok(())
-    }).await
+    })
+    .await
 }
 
-/// Refactored version of spl_token_client::token::Token::confidential_transfer_create_context_state_account().
-/// Instead of sending transactions internally, this function now returns the instructions to be used externally.
 fn get_zk_proof_context_state_account_creation_instructions<
     ZK: bytemuck::Pod + zk_elgamal_proof_program::proof_data::ZkProofData<U>,
     U: bytemuck::Pod,
@@ -397,9 +457,15 @@ fn get_zk_proof_context_state_account_creation_instructions<
     context_state_account_pubkey: &Pubkey,
     context_state_authority_pubkey: &Pubkey,
     proof_data: &ZK,
-) -> Result<(solana_sdk::instruction::Instruction, solana_sdk::instruction::Instruction), Box<dyn Error>> {
-    use std::mem::size_of;
+) -> Result<
+    (
+        solana_sdk::instruction::Instruction,
+        solana_sdk::instruction::Instruction,
+    ),
+    Box<dyn Error>,
+> {
     use spl_token_confidential_transfer_proof_extraction::instruction::zk_proof_type_to_instruction;
+    use std::mem::size_of;
 
     let client = get_rpc_client()?;
     let space = size_of::<zk_elgamal_proof_program::state::ProofContextState<U>>();
@@ -423,6 +489,5 @@ fn get_zk_proof_context_state_account_creation_instructions<
     let verify_proof_ix =
         instruction_type.encode_verify_proof(Some(context_state_info), proof_data);
 
-    // Return a tuple containing the create account instruction and verify proof instruction.
     Ok((create_account_ix, verify_proof_ix))
 }

--- a/ingredients/withdraw_tokens/src/lib.rs
+++ b/ingredients/withdraw_tokens/src/lib.rs
@@ -1,40 +1,30 @@
 use {
-    utils::{get_non_blocking_rpc_client, get_or_create_keypair, load_value, print_transaction_url},
-    solana_sdk::
-        signature::{Keypair, Signer}
-    ,
-    spl_associated_token_account::
-        get_associated_token_address_with_program_id
-    ,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_associated_token_account::get_associated_token_address_with_program_id,
     spl_token_2022::{
         extension::{
             confidential_transfer::{
-                account_info::
-                    WithdrawAccountInfo
-                ,
-                ConfidentialTransferAccount,
+                account_info::WithdrawAccountInfo, ConfidentialTransferAccount,
             },
             BaseStateWithExtensions,
         },
-        solana_zk_sdk::
-            encryption::{
-                auth_encryption::AeKey,
-                elgamal::ElGamalKeypair,
-            }
-        ,
+        solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
     },
     spl_token_client::{
-        client::{ProgramRpcClient, ProgramRpcClientSendTransaction, RpcClientResponse},
-        token::{ProofAccount, Token},
+        client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
+        token::Token,
     },
-    spl_token_confidential_transfer_proof_generation::
-        withdraw::WithdrawProofData
-    ,
+    spl_token_confidential_transfer_proof_generation::withdraw::WithdrawProofData,
     std::{error::Error, sync::Arc},
+    utils::{
+        get_non_blocking_rpc_client, get_or_create_keypair, load_value, print_transaction_url,
+    },
 };
 
-pub async fn withdraw_tokens(withdraw_amount: u64, recipient_signer: Arc<dyn Signer>) -> Result<(), Box<dyn Error>> {
-    
+pub async fn withdraw_tokens(
+    withdraw_amount: u64,
+    recipient_signer: Arc<dyn Signer>,
+) -> Result<(), Box<dyn Error>> {
     let mint = get_or_create_keypair("mint")?;
     let decimals = load_value("mint_decimals")?;
     let recipient_associated_token_address = get_associated_token_address_with_program_id(
@@ -61,11 +51,16 @@ pub async fn withdraw_tokens(withdraw_amount: u64, recipient_signer: Arc<dyn Sig
         )
     };
 
-    let receiver_elgamal_keypair =
-        ElGamalKeypair::new_from_signer(&recipient_signer, &recipient_associated_token_address.to_bytes())
-            .unwrap();
-    let receiver_aes_key =
-        AeKey::new_from_signer(&recipient_signer, &recipient_associated_token_address.to_bytes()).unwrap();
+    let receiver_elgamal_keypair = ElGamalKeypair::new_from_signer(
+        &recipient_signer,
+        &recipient_associated_token_address.to_bytes(),
+    )
+    .unwrap();
+    let receiver_aes_key = AeKey::new_from_signer(
+        &recipient_signer,
+        &recipient_associated_token_address.to_bytes(),
+    )
+    .unwrap();
 
     // Get recipient token account data
     let token_account = token
@@ -101,7 +96,7 @@ pub async fn withdraw_tokens(withdraw_amount: u64, recipient_signer: Arc<dyn Sig
     let create_equality_proof_signer = &[&equality_proof_context_state_keypair];
     let create_range_proof_signer = &[&range_proof_context_state_keypair];
 
-    match token
+    let equality_sig = token
         .confidential_transfer_create_context_state_account(
             &equality_proof_context_state_pubkey,
             &context_state_authority_pubkey,
@@ -109,16 +104,13 @@ pub async fn withdraw_tokens(withdraw_amount: u64, recipient_signer: Arc<dyn Sig
             false,
             create_equality_proof_signer,
         )
-        .await
-    {
-        Ok(RpcClientResponse::Signature(signature)) => {
-            print_transaction_url("Equality Proof Context State Account", &signature.to_string());
-        }
-        _ => {
-            panic!("Unexpected result from create equality proof context state account");
-        }
-    }
-    match token
+        .await?;
+    print_transaction_url(
+        "Equality Proof Context State Account",
+        &equality_sig.to_string(),
+    );
+
+    let range_sig = token
         .confidential_transfer_create_context_state_account(
             &range_proof_context_state_pubkey,
             &context_state_authority_pubkey,
@@ -126,27 +118,15 @@ pub async fn withdraw_tokens(withdraw_amount: u64, recipient_signer: Arc<dyn Sig
             true,
             create_range_proof_signer,
         )
-        .await
-    {
-        Ok(RpcClientResponse::Signature(signature)) => {
-            print_transaction_url("Range Proof Context State Account", &signature.to_string());
-        }
-        _ => {
-            panic!("Unexpected result from create range proof context state account");
-        }
-    }
+        .await?;
+    print_transaction_url("Range Proof Context State Account", &range_sig.to_string());
 
-    // do the withdrawal
-    match token
+    let withdraw_sig = token
         .confidential_transfer_withdraw(
             &recipient_associated_token_address,
             &recipient_signer.pubkey(),
-            Some(&ProofAccount::ContextAccount(
-                equality_proof_context_state_pubkey,
-            )),
-            Some(&ProofAccount::ContextAccount(
-                range_proof_context_state_pubkey,
-            )),
+            Some(&equality_proof_context_state_pubkey),
+            Some(&range_proof_context_state_pubkey),
             withdraw_amount,
             decimals,
             Some(withdraw_account_info),
@@ -154,57 +134,36 @@ pub async fn withdraw_tokens(withdraw_amount: u64, recipient_signer: Arc<dyn Sig
             &receiver_aes_key,
             &[&recipient_signer],
         )
-        .await
-    {
-        Ok(RpcClientResponse::Signature(signature)) => {
-            print_transaction_url("Withdraw Transaction", &signature.to_string());
-        }
-        Ok(RpcClientResponse::Transaction(_)) => {
-            panic!("Unexpected result from withdraw: transaction");
-        }
-        Ok(RpcClientResponse::Simulation(_)) => {
-            panic!("Unexpected result from withdraw: simulation");
-        }
-        Err(e) => {
-            panic!("Unexpected result from withdraw: {:?}", e);
-        }
-    }
+        .await?;
+    print_transaction_url("Withdraw Transaction", &withdraw_sig.to_string());
 
-    // close context state account
     let close_context_state_signer = &[&context_state_authority];
 
-    match token
+    let close_equality_sig = token
         .confidential_transfer_close_context_state_account(
             &equality_proof_context_state_pubkey,
             &recipient_associated_token_address,
             &context_state_authority_pubkey,
             close_context_state_signer,
         )
-        .await
-    {
-        Ok(RpcClientResponse::Signature(signature)) => {
-            print_transaction_url("Close Equality Proof Context State Account", &signature.to_string());
-        }
-        _ => {
-            panic!("Unexpected result from close equality proof context state account");
-        }
-    }
-    match token
+        .await?;
+    print_transaction_url(
+        "Close Equality Proof Context State Account",
+        &close_equality_sig.to_string(),
+    );
+
+    let close_range_sig = token
         .confidential_transfer_close_context_state_account(
             &range_proof_context_state_pubkey,
             &recipient_associated_token_address,
             &context_state_authority_pubkey,
             close_context_state_signer,
         )
-        .await
-    {
-        Ok(RpcClientResponse::Signature(signature)) => {
-            print_transaction_url("Close Range Proof Context State Account", &signature.to_string());
-        }
-        _ => {
-            panic!("Unexpected result from close range proof context state account");
-        }
-    }
-    
+        .await?;
+    print_transaction_url(
+        "Close Range Proof Context State Account",
+        &close_range_sig.to_string(),
+    );
+
     Ok(())
 }

--- a/recipes/Cargo.toml
+++ b/recipes/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 solana-sdk = { workspace = true }
 tokio = { workspace = true }
-solana-zk-sdk = { workspace = true }
+spl-token-2022 = { workspace = true }
 setup_participants = { path = "../ingredients/setup_participants" }
 setup_mint = { path = "../ingredients/setup_mint" }
 setup_token_account = { path = "../ingredients/setup_token_account" }

--- a/recipes/src/lib.rs
+++ b/recipes/src/lib.rs
@@ -5,7 +5,6 @@ mod recipe {
 
     use apply_pending_balance;
     use deposit_tokens;
-    use utils::{get_or_create_keypair, get_or_create_keypair_elgamal};
     use mint_tokens;
     use setup_mint;
     use setup_mint_confidential;
@@ -13,6 +12,7 @@ mod recipe {
     use setup_token_account;
     use solana_sdk::{native_token::LAMPORTS_PER_SOL, signer::Signer};
     use transfer;
+    use utils::{get_or_create_keypair, get_or_create_keypair_elgamal};
     use withdraw_tokens;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -24,18 +24,40 @@ mod recipe {
         let absolute_mint_authority = get_or_create_keypair("absolute_mint_authority")?;
 
         // Step 1. Setup participants
-        setup_participants::setup_basic_participant(&fee_payer_keypair.pubkey(), None, 2 * LAMPORTS_PER_SOL).await?;
-        setup_participants::setup_basic_participant(&sender_keypair.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL).await?;
-        setup_participants::setup_basic_participant(&recipient_keypair.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/5).await?;
+        setup_participants::setup_basic_participant(
+            &fee_payer_keypair.pubkey(),
+            None,
+            2 * LAMPORTS_PER_SOL,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &sender_keypair.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &recipient_keypair.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL / 5,
+        )
+        .await?;
 
         // Step 2. Create mint
-        setup_mint_confidential::create_mint(&absolute_mint_authority, &auditor_elgamal_keypair).await?;
+        setup_mint_confidential::create_mint(&absolute_mint_authority, &auditor_elgamal_keypair)
+            .await?;
 
         // Step 3. Setup token account for sender
         setup_token_account::setup_token_account(&sender_keypair).await?;
 
         // Step 4. Confidentially mint tokens
-        mint_tokens::go_with_confidential_mintburn(&absolute_mint_authority, &sender_keypair.pubkey(), 100_00, &auditor_elgamal_keypair).await?;
+        mint_tokens::go_with_confidential_mintburn(
+            &absolute_mint_authority,
+            &sender_keypair.pubkey(),
+            100_00,
+            &auditor_elgamal_keypair,
+        )
+        .await?;
 
         Ok(())
     }
@@ -49,9 +71,24 @@ mod recipe {
         let absolute_mint_authority = get_or_create_keypair("absolute_mint_authority")?;
 
         // Step 1. Setup participants
-        setup_participants::setup_basic_participant(&fee_payer_keypair.pubkey(), None, 2 * LAMPORTS_PER_SOL).await?;
-        setup_participants::setup_basic_participant(&sender_keypair.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/2).await?;
-        setup_participants::setup_basic_participant(&recipient_keypair.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/5).await?;
+        setup_participants::setup_basic_participant(
+            &fee_payer_keypair.pubkey(),
+            None,
+            2 * LAMPORTS_PER_SOL,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &sender_keypair.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL / 2,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &recipient_keypair.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL / 5,
+        )
+        .await?;
 
         // Step 2. Create mint
         setup_mint::create_mint(&absolute_mint_authority, &auditor_elgamal_keypair).await?;
@@ -72,7 +109,8 @@ mod recipe {
         setup_token_account::setup_token_account(&recipient_keypair).await?;
 
         // Step 8. Transfer tokens with split proofs
-        transfer::with_split_proofs(sender_keypair.clone(), recipient_keypair.clone(), 50_00).await?;
+        transfer::with_split_proofs(sender_keypair.clone(), recipient_keypair.clone(), 50_00)
+            .await?;
 
         // Step 9. Apply recipient's pending balance
         apply_pending_balance::apply_pending_balance(&recipient_keypair).await?;
@@ -95,9 +133,24 @@ mod recipe {
         let absolute_mint_authority = get_or_create_keypair("absolute_mint_authority")?;
 
         // Step 1. Setup participants
-        setup_participants::setup_basic_participant(&fee_payer_keypair.pubkey(), None, 2 * LAMPORTS_PER_SOL).await?;
-        setup_participants::setup_basic_participant(&sender_keypair.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/2).await?;
-        setup_participants::setup_basic_participant(&recipient_keypair.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/5).await?;
+        setup_participants::setup_basic_participant(
+            &fee_payer_keypair.pubkey(),
+            None,
+            2 * LAMPORTS_PER_SOL,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &sender_keypair.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL / 2,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &recipient_keypair.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL / 5,
+        )
+        .await?;
 
         // Step 2. Create mint
         setup_mint::create_mint(&absolute_mint_authority, &auditor_elgamal_keypair).await?;
@@ -118,7 +171,12 @@ mod recipe {
         setup_token_account::setup_token_account(&recipient_keypair).await?;
 
         // Step 8. Transfer tokens with split proofs
-        transfer::with_split_proofs_atomic(sender_keypair.clone(), recipient_keypair.clone(), 50_00).await?;
+        transfer::with_split_proofs_atomic(
+            sender_keypair.clone(),
+            recipient_keypair.clone(),
+            50_00,
+        )
+        .await?;
 
         // Step 9. Apply recipient's pending balance
         apply_pending_balance::apply_pending_balance(&recipient_keypair).await?;
@@ -133,65 +191,6 @@ mod recipe {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn basic_transfer_recipe_turnkey() -> Result<(), Box<dyn Error>> {
-
-        let sender_signer = utils::get_turnkey_signers_from_env(
-            "TURNKEY_SENDER_PRIVATE_KEY_ID",
-            "TURNKEY_SENDER_PUBLIC_KEY"
-        )?;
-
-        let recipient_signer = utils::get_turnkey_signers_from_env(
-            "TURNKEY_RECEIVER_PRIVATE_KEY_ID",
-            "TURNKEY_RECEIVER_PUBLIC_KEY"
-        )?;
-
-        let recipient_signer = Arc::new(recipient_signer);
-        let sender_signer = Arc::new(sender_signer);
-
-        let fee_payer_keypair = get_or_create_keypair("fee_payer_keypair")?;
-        let auditor_elgamal_keypair = get_or_create_keypair_elgamal("auditor_elgamal")?;
-        let absolute_mint_authority = get_or_create_keypair("absolute_mint_authority")?;
-
-        // Step 1. Setup participants
-        setup_participants::setup_basic_participant(&fee_payer_keypair.pubkey(), None, 2 * LAMPORTS_PER_SOL).await?;
-        setup_participants::setup_basic_participant(&sender_signer.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/2).await?;
-        setup_participants::setup_basic_participant(&recipient_signer.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/5).await?;
-
-        // Step 2. Create mint
-        setup_mint::create_mint(&absolute_mint_authority, &auditor_elgamal_keypair).await?;
-
-        // Step 3. Setup token account for sender
-        setup_token_account::setup_token_account(&sender_signer).await?;
-
-        // Step 4. Mint tokens
-        mint_tokens::go(&absolute_mint_authority, &sender_signer.pubkey(), 100_00).await?;
-
-        // Step 5. Deposit tokens
-        deposit_tokens::deposit_tokens(50_00, &sender_signer).await?;
-
-        // Step 6. Apply pending balance
-        apply_pending_balance::apply_pending_balance(&sender_signer).await?;
-
-        // Step 7. Create recipient token account
-        setup_token_account::setup_token_account(&recipient_signer).await?;
-
-        // Step 8. Transfer tokens with split proofs
-        transfer::with_split_proofs(sender_signer.clone(), recipient_signer.clone(), 50_00).await?;
-
-        // Step 9. Apply recipient's pending balance
-        apply_pending_balance::apply_pending_balance(&recipient_signer).await?;
-
-        // Step 10. Withdraw tokens
-        withdraw_tokens::withdraw_tokens(20_00, recipient_signer.clone()).await?;
-
-        // Step 11. Auditor asserts last transfer amount
-        global_auditor_assert::last_transfer_amount(50_00, &auditor_elgamal_keypair).await?;
-
-        Ok(())
-    }
-
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn basic_transfer_recipe_gcp() -> Result<(), Box<dyn Error>> {
         let sender_signer = utils::get_gcp_signer_from_env("projects/cookbook-448105/locations/us-west1/keyRings/test/cryptoKeys/first_key/cryptoKeyVersions/1").await?;
         let recipient_signer = utils::get_gcp_signer_from_env("projects/cookbook-448105/locations/us-west1/keyRings/test/cryptoKeys/second_key/cryptoKeyVersions/1").await?;
@@ -204,9 +203,24 @@ mod recipe {
         let absolute_mint_authority = get_or_create_keypair("absolute_mint_authority")?;
 
         // Step 1. Setup participants
-        setup_participants::setup_basic_participant(&fee_payer_keypair.pubkey(), None, 2 * LAMPORTS_PER_SOL).await?;
-        setup_participants::setup_basic_participant(&sender_signer.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/2).await?;
-        setup_participants::setup_basic_participant(&recipient_signer.pubkey(), Some(&fee_payer_keypair), LAMPORTS_PER_SOL/5).await?;
+        setup_participants::setup_basic_participant(
+            &fee_payer_keypair.pubkey(),
+            None,
+            2 * LAMPORTS_PER_SOL,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &sender_signer.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL / 2,
+        )
+        .await?;
+        setup_participants::setup_basic_participant(
+            &recipient_signer.pubkey(),
+            Some(&fee_payer_keypair),
+            LAMPORTS_PER_SOL / 5,
+        )
+        .await?;
 
         // Step 2. Create mint
         setup_mint::create_mint(&absolute_mint_authority, &auditor_elgamal_keypair).await?;
@@ -240,5 +254,4 @@ mod recipe {
 
         Ok(())
     }
-
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -5,15 +5,22 @@ edition = "2021"
 
 [dependencies]
 solana-sdk = { workspace = true }
+solana-commitment-config = "3.0.0"
+solana-keypair = "3.1.0"
+solana-signer = "3.0.0"
+solana-instruction = "3.1.0"
+solana-native-token = "3.0.0"
+solana-pubkey = "3.0.0"
+solana-system-interface = "2.0.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
-solana-zk-sdk = { workspace = true }
+spl-token-2022 = { workspace = true }
 solana-client = { workspace = true }
 dotenvy = { workspace = true }
-tk-rs = { workspace = true }
 tokio = { workspace = true }
 google-cloud-kms = { workspace = true }
 base64 = { workspace = true }
 bs58 = { workspace = true }
 jito-sdk-rust = { workspace = true }
 reqwest = { version = "0.12.11", features = ["json"] }
+hex = "0.4"

--- a/utils/src/gcp.rs
+++ b/utils/src/gcp.rs
@@ -1,87 +1,86 @@
+use std::error::Error;
 
-    use std::error::Error;
+use base64::Engine;
 
-    use base64::Engine;
+use google_cloud_kms::{
+    client::{Client, ClientConfig},
+    grpc::kms::v1::{AsymmetricSignRequest, GetPublicKeyRequest},
+};
+use solana_sdk::pubkey::Pubkey;
 
-    use google_cloud_kms::{
-        client::{Client, ClientConfig},
-        grpc::kms::v1::{
-            AsymmetricSignRequest, GetPublicKeyRequest,
-        },
-    };
-    use solana_sdk::pubkey::Pubkey;
+pub struct GcpSigner {
+    client: Client,
 
-    pub struct GcpSigner {
-        client: Client,
+    // Example: "projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*"
+    resource_name: String,
+}
 
-        // Example: "projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*"
-        resource_name: String,
+impl GcpSigner {
+    pub async fn new(resource_name: String) -> Result<Self, Box<dyn Error>> {
+        let config = ClientConfig::default().with_auth().await?;
+        let client = Client::new(config).await?;
+        Ok(Self {
+            client,
+            resource_name: resource_name,
+        })
     }
+}
 
-    impl GcpSigner {
-        pub async fn new(resource_name: String) -> Result<Self, Box<dyn Error>> {
-            let config = ClientConfig::default().with_auth().await?;
-            let client = Client::new(config).await?;
-            Ok(Self {
-                client,
-                resource_name: resource_name,
+fn decode_pem(pem: &str) -> Result<Pubkey, Box<dyn Error>> {
+    // Step 1: Strip PEM headers
+    let pem_body = pem
+        .lines()
+        .filter(|line| !line.starts_with("-----"))
+        .collect::<Vec<_>>()
+        .join("");
+
+    // Step 2: Decode the base64 PEM body
+    let der_bytes = base64::engine::general_purpose::STANDARD.decode(&pem_body)?;
+
+    // Step 3: Extract the raw public key
+    // For Ed25519, the raw key is the last 32 bytes of the DER structure
+    let raw_key = &der_bytes[der_bytes.len() - 32..];
+
+    // Step 4: Convert the raw key to a Pubkey
+    Pubkey::try_from(raw_key).map_err(|e| Box::new(e) as Box<dyn Error>)
+}
+
+impl solana_sdk::signer::Signer for GcpSigner {
+    fn try_pubkey(&self) -> Result<Pubkey, solana_sdk::signer::SignerError> {
+        // START Blocking thread...
+        tokio::task::block_in_place(|| {
+            let handle = tokio::runtime::Handle::current();
+            handle.block_on(async {
+                // START logic
+                let resp = self
+                    .client
+                    .get_public_key(
+                        GetPublicKeyRequest {
+                            name: self.resource_name.clone(),
+                        },
+                        None,
+                    )
+                    .await
+                    .map_err(|e| solana_sdk::signer::SignerError::Custom(e.to_string()));
+
+                decode_pem(&resp.unwrap().pem)
+                    .map_err(|e| solana_sdk::signer::SignerError::Custom(e.to_string()))
+                // END logic
             })
-        }
+        })
+        // END Blocking thread...
     }
 
-    fn decode_pem(pem: &str) -> Result<Pubkey, Box<dyn Error>> {
-        // Step 1: Strip PEM headers
-        let pem_body = pem
-            .lines()
-            .filter(|line| !line.starts_with("-----"))
-            .collect::<Vec<_>>()
-            .join("");
-
-        // Step 2: Decode the base64 PEM body
-        let der_bytes = base64::engine::general_purpose::STANDARD.decode(&pem_body)?;
-
-        // Step 3: Extract the raw public key
-        // For Ed25519, the raw key is the last 32 bytes of the DER structure
-        let raw_key = &der_bytes[der_bytes.len() - 32..];
-
-        // Step 4: Convert the raw key to a Pubkey
-        Pubkey::try_from(raw_key).map_err(|e| Box::new(e) as Box<dyn Error>)
-    }
-
-    impl solana_sdk::signer::Signer for GcpSigner {
-        fn try_pubkey(&self) -> Result<Pubkey, solana_sdk::signer::SignerError> {
-            // START Blocking thread...
-            tokio::task::block_in_place(|| {
-                let handle = tokio::runtime::Handle::current();
-                handle.block_on(async {
-                    // START logic
-                    let resp = self
-                        .client
-                        .get_public_key(
-                            GetPublicKeyRequest {
-                                name: self.resource_name.clone(),
-                            },
-                            None,
-                        )
-                        .await
-                        .map_err(|e| solana_sdk::signer::SignerError::Custom(e.to_string()));
-
-                    decode_pem(&resp.unwrap().pem)
-                        .map_err(|e| solana_sdk::signer::SignerError::Custom(e.to_string()))
-                    // END logic
-                })
-            })
-            // END Blocking thread...
-        }
-
-        fn try_sign_message(&self, message: &[u8]) -> Result<solana_sdk::signature::Signature, solana_sdk::signer::SignerError> {
-            // START Blocking thread...
-            tokio::task::block_in_place(|| {
-                let handle = tokio::runtime::Handle::current();
-                handle.block_on(async {
-
-                    // START logic
-                    let resp = self
+    fn try_sign_message(
+        &self,
+        message: &[u8],
+    ) -> Result<solana_sdk::signature::Signature, solana_sdk::signer::SignerError> {
+        // START Blocking thread...
+        tokio::task::block_in_place(|| {
+            let handle = tokio::runtime::Handle::current();
+            handle.block_on(async {
+                // START logic
+                let resp = self
                     .client
                     .asymmetric_sign(
                         AsymmetricSignRequest {
@@ -96,19 +95,24 @@
                     .await
                     .map_err(|e| solana_sdk::signer::SignerError::Custom(e.to_string()))?;
 
-                    let signature_bytes: [u8; 64] = resp.signature.as_slice().try_into().map_err(|_| solana_sdk::signer::SignerError::Custom("Invalid signature length".to_string()))?;
-                    let signature = solana_sdk::signature::Signature::from(signature_bytes);
-                    Ok(signature)
-                    // END logic
-                })
+                let signature_bytes: [u8; 64] =
+                    resp.signature.as_slice().try_into().map_err(|_| {
+                        solana_sdk::signer::SignerError::Custom(
+                            "Invalid signature length".to_string(),
+                        )
+                    })?;
+                let signature = solana_sdk::signature::Signature::from(signature_bytes);
+                Ok(signature)
+                // END logic
             })
-            // END Blocking thread...
-        }
-
-        fn is_interactive(&self) -> bool {
-            false
-        }
+        })
+        // END Blocking thread...
     }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
+}
 
 mod gcp_test {
     #[cfg(test)]
@@ -116,9 +120,9 @@ mod gcp_test {
     #[cfg(test)]
     use dotenvy;
     #[cfg(test)]
-    use solana_sdk::signer::Signer;
-    #[cfg(test)]
     use google_cloud_kms::grpc::kms::v1::ListKeyRingsRequest;
+    #[cfg(test)]
+    use solana_sdk::signer::Signer;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_signer() -> Result<(), Box<dyn Error>> {
@@ -129,7 +133,7 @@ mod gcp_test {
         println!("Pubkey: {:?}", pubkey);
 
         let signature = signer.try_sign_message(b"HelloWorld!")?;
-        println!("Signature: {:?}", tk_rs::bytes_to_hex(signature.as_ref().into()));
+        println!("Signature: {:?}", hex::encode(signature.as_ref()));
         Ok(())
     }
 
@@ -192,9 +196,8 @@ mod gcp_test {
             None,
         ).await?;
 
-        println!("Signature: {:?}", tk_rs::bytes_to_hex(&resp.signature));
+        println!("Signature: {:?}", hex::encode(&resp.signature));
 
         Ok(())
     }
-
-    }
+}

--- a/utils/src/jito.rs
+++ b/utils/src/jito.rs
@@ -1,12 +1,9 @@
 use {
+    jito_sdk_rust::JitoJsonRpcSDK, reqwest, serde_json::Value, solana_instruction::Instruction,
+    solana_native_token::LAMPORTS_PER_SOL, solana_pubkey::Pubkey,
+    solana_system_interface::instruction as system_instruction, std::str::FromStr,
     std::time::Duration,
-    solana_sdk::{instruction::Instruction, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, system_instruction},
-    jito_sdk_rust::JitoJsonRpcSDK,
-    std::str::FromStr,
-    reqwest,
-    serde_json::Value
 };
-
 
 #[derive(Debug)]
 pub struct BundleStatus {
@@ -19,12 +16,14 @@ pub const MAX_RETRIES: u32 = 40;
 pub const RETRY_DELAY: Duration = Duration::from_secs(3);
 pub const JITO_ENGINE_URL: &str = "https://dallas.testnet.block-engine.jito.wtf/api/v1";
 
-pub async fn create_jito_tip_instruction(sender_pubkey: Pubkey) -> Result<Instruction, Box<dyn std::error::Error>> {
+pub async fn create_jito_tip_instruction(
+    sender_pubkey: Pubkey,
+) -> Result<Instruction, Box<dyn std::error::Error>> {
     let jito_sdk = JitoJsonRpcSDK::new(JITO_ENGINE_URL, None);
 
     let random_tip_account = jito_sdk.get_random_tip_account().await?;
     let jito_tip_account = Pubkey::from_str(&random_tip_account)?;
-    let jito_tip_amount:u64 = get_max_tip_amount().await?;
+    let jito_tip_amount: u64 = get_max_tip_amount().await?;
     println!("Jito tip lamports: {}", jito_tip_amount);
 
     Ok(system_instruction::transfer(
@@ -33,15 +32,19 @@ pub async fn create_jito_tip_instruction(sender_pubkey: Pubkey) -> Result<Instru
         jito_tip_amount,
     ))
 }
-pub async fn submit_and_confirm_bundle(bundle: serde_json::Value) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-
+pub async fn submit_and_confirm_bundle(
+    bundle: serde_json::Value,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let jito_sdk = JitoJsonRpcSDK::new(JITO_ENGINE_URL, None);
 
     // UUID for the bundle
     let uuid = None;
 
     // Send bundle using Jito SDK
-    println!("Sending bundle with {} transactions...", bundle.as_array().unwrap().len());
+    println!(
+        "Sending bundle with {} transactions...",
+        bundle.as_array().unwrap().len()
+    );
     let response = jito_sdk.send_bundle(Some(bundle), uuid).await?;
 
     // Extract bundle UUID from response
@@ -51,14 +54,20 @@ pub async fn submit_and_confirm_bundle(bundle: serde_json::Value) -> Result<Vec<
     println!("Bundle sent with UUID: {}", bundle_uuid);
 
     confirm_bundle_status(&jito_sdk, &bundle_uuid).await
-    
 }
-pub async fn confirm_bundle_status(jito_sdk: &JitoJsonRpcSDK, bundle_uuid: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-
+pub async fn confirm_bundle_status(
+    jito_sdk: &JitoJsonRpcSDK,
+    bundle_uuid: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     for attempt in 1..=MAX_RETRIES {
-        println!("Checking bundle status (attempt {}/{})", attempt, MAX_RETRIES);
+        println!(
+            "Checking bundle status (attempt {}/{})",
+            attempt, MAX_RETRIES
+        );
 
-        let status_response = jito_sdk.get_in_flight_bundle_statuses(vec![bundle_uuid.to_string()]).await?;
+        let status_response = jito_sdk
+            .get_in_flight_bundle_statuses(vec![bundle_uuid.to_string()])
+            .await?;
 
         if let Some(result) = status_response.get("result") {
             if let Some(value) = result.get("value") {
@@ -68,17 +77,21 @@ pub async fn confirm_bundle_status(jito_sdk: &JitoJsonRpcSDK, bundle_uuid: &str)
                             match status.as_str() {
                                 Some("Landed") => {
                                     println!("Bundle landed on-chain. Checking final status...");
-                                    return Ok(check_final_bundle_status(&jito_sdk, bundle_uuid).await?);
-                                },
+                                    return Ok(
+                                        check_final_bundle_status(&jito_sdk, bundle_uuid).await?
+                                    );
+                                }
                                 Some("Pending") => {
                                     println!("Bundle is pending. Waiting...");
-                                },
+                                }
                                 Some(status) => {
                                     if status == "Failed" {
-                                        return Err(format!("Bundle failed to land on-chain").into());
+                                        return Err(
+                                            format!("Bundle failed to land on-chain").into()
+                                        );
                                     }
                                     println!("Unexpected bundle status: {}. Waiting...", status);
-                                },
+                                }
                                 None => {
                                     println!("Unable to parse bundle status. Waiting...");
                                 }
@@ -94,7 +107,6 @@ pub async fn confirm_bundle_status(jito_sdk: &JitoJsonRpcSDK, bundle_uuid: &str)
                 }
             } else {
                 println!("Value field not found in result. Waiting...");
-
             }
         } else if let Some(error) = status_response.get("error") {
             println!("Error checking bundle status: {:?}", error);
@@ -107,7 +119,11 @@ pub async fn confirm_bundle_status(jito_sdk: &JitoJsonRpcSDK, bundle_uuid: &str)
         }
     }
 
-    Err(format!("Failed to confirm bundle status after {} attempts", MAX_RETRIES).into())
+    Err(format!(
+        "Failed to confirm bundle status after {} attempts",
+        MAX_RETRIES
+    )
+    .into())
 }
 
 pub async fn get_max_tip_amount() -> Result<u64, Box<dyn std::error::Error>> {
@@ -120,7 +136,10 @@ pub async fn get_max_tip_amount() -> Result<u64, Box<dyn std::error::Error>> {
         .as_f64()
         .ok_or("Failed to parse landed_tips_99th_percentile")?;
 
-    println!("Jito landed_tips_99th_percentile: {}", landed_tips_99th_percentile);
+    println!(
+        "Jito landed_tips_99th_percentile: {}",
+        landed_tips_99th_percentile
+    );
 
     // Convert SOL to Lamports
     let jito_tip_amount = (landed_tips_99th_percentile * LAMPORTS_PER_SOL as f64) as u64;
@@ -128,12 +147,19 @@ pub async fn get_max_tip_amount() -> Result<u64, Box<dyn std::error::Error>> {
     Ok(jito_tip_amount)
 }
 
-async fn check_final_bundle_status(jito_sdk: &JitoJsonRpcSDK, bundle_uuid: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-
+async fn check_final_bundle_status(
+    jito_sdk: &JitoJsonRpcSDK,
+    bundle_uuid: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     for attempt in 1..=MAX_RETRIES {
-        println!("Checking final bundle status (attempt {}/{})", attempt, MAX_RETRIES);
+        println!(
+            "Checking final bundle status (attempt {}/{})",
+            attempt, MAX_RETRIES
+        );
 
-        let status_response = jito_sdk.get_bundle_statuses(vec![bundle_uuid.to_string()]).await?;
+        let status_response = jito_sdk
+            .get_bundle_statuses(vec![bundle_uuid.to_string()])
+            .await?;
         let bundle_status = get_bundle_status(&status_response)?;
 
         match bundle_status.confirmation_status.as_deref() {
@@ -142,20 +168,27 @@ async fn check_final_bundle_status(jito_sdk: &JitoJsonRpcSDK, bundle_uuid: &str)
                 check_transaction_error(&bundle_status)?;
                 return match bundle_status.transactions {
                     Some(transactions) => Ok(transactions),
-                    None => Err("Error retrieving transactions from finalized bundle status".into()),
+                    None => {
+                        Err("Error retrieving transactions from finalized bundle status".into())
+                    }
                 };
-            },
+            }
             Some("finalized") => {
                 println!("Bundle finalized on-chain successfully!");
                 check_transaction_error(&bundle_status)?;
                 return match bundle_status.transactions {
                     Some(transactions) => Ok(transactions),
-                    None => Err("Error retrieving transactions from finalized bundle status".into()),
+                    None => {
+                        Err("Error retrieving transactions from finalized bundle status".into())
+                    }
                 };
-            },
+            }
             Some(status) => {
-                println!("Unexpected final bundle status: {}. Continuing to poll...", status);
-            },
+                println!(
+                    "Unexpected final bundle status: {}. Continuing to poll...",
+                    status
+                );
+            }
             None => {
                 println!("Unable to parse final bundle status. Continuing to poll...");
             }
@@ -166,10 +199,16 @@ async fn check_final_bundle_status(jito_sdk: &JitoJsonRpcSDK, bundle_uuid: &str)
         }
     }
 
-    Err(format!("Failed to get finalized status after {} attempts", MAX_RETRIES).into())
+    Err(format!(
+        "Failed to get finalized status after {} attempts",
+        MAX_RETRIES
+    )
+    .into())
 }
 
-fn get_bundle_status(status_response: &serde_json::Value) -> Result<BundleStatus, Box<dyn std::error::Error>> {
+fn get_bundle_status(
+    status_response: &serde_json::Value,
+) -> Result<BundleStatus, Box<dyn std::error::Error>> {
     status_response
         .get("result")
         .and_then(|result| result.get("value"))
@@ -177,11 +216,19 @@ fn get_bundle_status(status_response: &serde_json::Value) -> Result<BundleStatus
         .and_then(|statuses| statuses.get(0))
         .ok_or_else(|| format!("Failed to parse bundle status").into())
         .map(|bundle_status| BundleStatus {
-            confirmation_status: bundle_status.get("confirmation_status").and_then(|s| s.as_str()).map(String::from),
+            confirmation_status: bundle_status
+                .get("confirmation_status")
+                .and_then(|s| s.as_str())
+                .map(String::from),
             err: bundle_status.get("err").cloned(),
-            transactions: bundle_status.get("transactions").and_then(|t| t.as_array()).map(|arr| {
-                arr.iter().filter_map(|v| v.as_str().map(String::from)).collect()
-            }),
+            transactions: bundle_status
+                .get("transactions")
+                .and_then(|t| t.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                }),
         })
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,22 +1,30 @@
+use dotenvy;
 use gcp::GcpSigner;
 use solana_client::nonblocking::rpc_client::RpcClient as NonBlockingRpcClient;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
-use solana_sdk::signer::keypair::Keypair;
-use solana_sdk::signer::Signer;
-use solana_zk_sdk::encryption::auth_encryption::AeKey;
-use solana_zk_sdk::encryption::elgamal::{ElGamalKeypair, ElGamalSecretKey};
+use solana_commitment_config::CommitmentConfig;
+use solana_keypair::Keypair;
+use spl_token_2022::solana_zk_sdk::encryption::elgamal::{ElGamalKeypair, ElGamalSecretKey};
 use std::env;
 use std::error::Error;
 use std::fs::OpenOptions;
 use std::io::Write;
-use dotenvy;
 
 pub mod gcp;
 pub mod jito;
 
 pub const ENV_FILE_PATH: &str = "../.env";
 pub const RUNTIME_ENV_FILE_PATH: &str = "../runtime_output.env";
+
+/// Helper to create a Keypair from a 64-byte array (secret + public key)
+fn keypair_from_bytes(bytes: &[u8]) -> Result<Keypair, Box<dyn Error>> {
+    if bytes.len() != 64 {
+        return Err(format!("Expected 64 bytes for keypair, got {}", bytes.len()).into());
+    }
+    // The first 32 bytes are the secret key
+    let secret_key: [u8; 32] = bytes[..32].try_into()?;
+    Ok(Keypair::new_from_array(secret_key))
+}
 
 // Get or create a keypair from an .env file
 pub fn get_or_create_keypair(variable_name: &str) -> Result<Keypair, Box<dyn Error>> {
@@ -26,10 +34,10 @@ pub fn get_or_create_keypair(variable_name: &str) -> Result<Keypair, Box<dyn Err
         if let Ok(secret_key_string) = env::var(variable_name) {
             // Try to parse from runtime_output.env
             let decoded_secret_key: Vec<u8> = serde_json::from_str(&secret_key_string)?;
-            return Ok(Keypair::from_bytes(&decoded_secret_key)?);
+            return keypair_from_bytes(&decoded_secret_key);
         }
     }
-    
+
     // Then check original .env
     dotenvy::from_filename_override(ENV_FILE_PATH).ok();
 
@@ -37,7 +45,7 @@ pub fn get_or_create_keypair(variable_name: &str) -> Result<Keypair, Box<dyn Err
         Ok(secret_key_string) => {
             // Parse from .env
             let decoded_secret_key: Vec<u8> = serde_json::from_str(&secret_key_string)?;
-            Ok(Keypair::from_bytes(&decoded_secret_key)?)
+            keypair_from_bytes(&decoded_secret_key)
         }
         Err(_) => {
             // Create a new keypair if the environment variable is not found in either file
@@ -53,7 +61,10 @@ pub fn get_or_create_keypair(variable_name: &str) -> Result<Keypair, Box<dyn Err
             }
 
             // Open runtime_output.env file, create it if it does not exist
-            let mut file = OpenOptions::new().append(true).create(true).open(RUNTIME_ENV_FILE_PATH)?;
+            let mut file = OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(RUNTIME_ENV_FILE_PATH)?;
 
             writeln!(file, "{}={}", variable_name, json_secret_key)?;
 
@@ -61,40 +72,35 @@ pub fn get_or_create_keypair(variable_name: &str) -> Result<Keypair, Box<dyn Err
         }
     }
 }
-pub fn get_turnkey_signer(private_key_id_env: &str, public_key_env: &str) -> Result<Box<dyn Signer + Send>, Box<dyn Error>> {
-    let signer = tk_rs::TurnkeySigner::new(
-        dotenvy::var("TURNKEY_API_PUBLIC_KEY").unwrap(),
-        dotenvy::var("TURNKEY_API_PRIVATE_KEY").unwrap(),
-        dotenvy::var("TURNKEY_ORGANIZATION_ID").unwrap(),
-        dotenvy::var(private_key_id_env).unwrap(),
-        dotenvy::var(public_key_env).unwrap(),
-    )?;
-    Ok(Box::new(signer))
-}
 
-
-pub fn get_or_create_keypair_elgamal(variable_name: &str) -> Result<ElGamalKeypair, Box<dyn Error>> {
+pub fn get_or_create_keypair_elgamal(
+    variable_name: &str,
+) -> Result<ElGamalKeypair, Box<dyn Error>> {
     // First check runtime_output.env if it exists
     if std::path::Path::new(RUNTIME_ENV_FILE_PATH).exists() {
         dotenvy::from_filename_override(RUNTIME_ENV_FILE_PATH).ok();
         if let Ok(secret_key_string) = env::var(variable_name) {
             // Try to parse from runtime_output.env
             let decoded_secret_key: Vec<u8> = serde_json::from_str(&secret_key_string)?;
-            return Ok(ElGamalKeypair::new(ElGamalSecretKey::from_seed(&decoded_secret_key)?));
+            return Ok(ElGamalKeypair::new(ElGamalSecretKey::from_seed(
+                &decoded_secret_key,
+            )?));
         }
     }
-    
+
     // Then check original .env
     dotenvy::from_filename_override(ENV_FILE_PATH).ok();
 
     match env::var(variable_name) {
         Ok(secret_key_string) => {
             let decoded_secret_key: Vec<u8> = serde_json::from_str(&secret_key_string)?;
-            Ok(ElGamalKeypair::new(ElGamalSecretKey::from_seed(&decoded_secret_key)?))
+            Ok(ElGamalKeypair::new(ElGamalSecretKey::from_seed(
+                &decoded_secret_key,
+            )?))
         }
         Err(_) => {
             let keypair = ElGamalKeypair::new_rand();
-            
+
             // Convert secret key to Vec<u8> and then to JSON, append to runtime_output.env file
             let secret_key_bytes = Vec::from(keypair.secret().as_bytes());
             let json_secret_key = serde_json::to_string(&secret_key_bytes)?;
@@ -105,16 +111,22 @@ pub fn get_or_create_keypair_elgamal(variable_name: &str) -> Result<ElGamalKeypa
             }
 
             // Open runtime_output.env file, create it if it does not exist
-            let mut file = OpenOptions::new().append(true).create(true).open(RUNTIME_ENV_FILE_PATH)?;
+            let mut file = OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(RUNTIME_ENV_FILE_PATH)?;
 
             writeln!(file, "{}={}", variable_name, json_secret_key)?;
 
             Ok(keypair)
-        },
+        }
     }
 }
 
-pub fn record_value<'a, T: serde::Serialize>(variable_name: &str, value: T) -> Result<T, Box<dyn Error>> {
+pub fn record_value<'a, T: serde::Serialize>(
+    variable_name: &str,
+    value: T,
+) -> Result<T, Box<dyn Error>> {
     // Serialize the value to a JSON string
     let json_value = serde_json::to_string(&value)?;
 
@@ -142,19 +154,21 @@ pub fn record_value<'a, T: serde::Serialize>(variable_name: &str, value: T) -> R
     Ok(value)
 }
 
-pub fn load_value<T: serde::de::DeserializeOwned>(variable_name: &str) -> Result<T, Box<dyn Error>> {
+pub fn load_value<T: serde::de::DeserializeOwned>(
+    variable_name: &str,
+) -> Result<T, Box<dyn Error>> {
     // First try to load from runtime_output.env
     if std::path::Path::new(RUNTIME_ENV_FILE_PATH).exists() {
         dotenvy::from_filename_override(RUNTIME_ENV_FILE_PATH).ok();
         if let Ok(env_value) = env::var(variable_name) {
             // Try to deserialize the JSON string to the object
             let value: Result<T, _> = serde_json::from_str(&env_value);
-            
+
             // If deserialization succeeds, return the value
             if let Ok(val) = value {
                 return Ok(val);
             }
-            
+
             // Try to parse as a plain string
             let plain_value: Result<T, _> = serde_json::from_str(&format!("\"{}\"", env_value));
             if let Ok(val) = plain_value {
@@ -162,10 +176,10 @@ pub fn load_value<T: serde::de::DeserializeOwned>(variable_name: &str) -> Result
             }
         }
     }
-    
+
     // If not found in runtime_output.env, try the original .env
     dotenvy::from_filename_override(ENV_FILE_PATH).ok();
-    
+
     // Get the environment variable
     let env_value = env::var(variable_name)?;
 
@@ -193,7 +207,7 @@ pub fn get_rpc_client() -> Result<RpcClient, Box<dyn Error>> {
     Ok(client)
 }
 
-pub fn get_non_blocking_rpc_client() -> Result<NonBlockingRpcClient, Box<dyn Error>> {  
+pub fn get_non_blocking_rpc_client() -> Result<NonBlockingRpcClient, Box<dyn Error>> {
     dotenvy::from_filename_override(ENV_FILE_PATH).ok();
 
     let client = NonBlockingRpcClient::new_with_commitment(
@@ -203,57 +217,14 @@ pub fn get_non_blocking_rpc_client() -> Result<NonBlockingRpcClient, Box<dyn Err
     Ok(client)
 }
 
-/// Spawns a blocking task to generate both AeKey and ElGamalKeypair from a given signer.
-/// This utility function helps avoid Tokio runtime conflicts by isolating blocking operations.
-pub async fn tokio_spawn_blocking_turnkey_signer_keys(
-    private_key_id_env: &str,
-    public_key_env: &str,
-) -> Result<(Box<dyn Signer + Send>, AeKey, ElGamalKeypair), String> {
-    let private_key_id = private_key_id_env.to_string();
-    let public_key = public_key_env.to_string();
-    
-    tokio::task::spawn_blocking(move || -> Result<(Box<dyn Signer + Send>, AeKey, ElGamalKeypair), String> {
-        let signer = get_turnkey_signer(&private_key_id, &public_key)
-            .map_err(|e| e.to_string())?;
-        
-        let elgamal_keypair = ElGamalKeypair::new_from_signer(&signer, &signer.pubkey().to_bytes())
-            .map_err(|e| e.to_string())?;
-        
-        let aes_key = AeKey::new_from_signer(&signer, &signer.pubkey().to_bytes())
-            .map_err(|e| e.to_string())?;
-        
-        Ok((signer, aes_key, elgamal_keypair))
-    })
-    .await
-    .map_err(|e| e.to_string())?
-}
-
-pub fn get_turnkey_signers_from_env(
-    private_key_id_env: &str,
-    public_key_env: &str,
-) -> Result<Box<dyn Signer + Send>, String> {
-    let private_key_id = private_key_id_env.to_string();
-    let public_key = public_key_env.to_string();
-    
-    let signer = get_turnkey_signer(&private_key_id, &public_key)
-        .map_err(|e| e.to_string())?;
-    
-    Ok(signer)
-}
-
-pub async fn get_gcp_signer_from_env(
-    resource_name: &str,
-) -> Result<GcpSigner, Box<dyn Error>> {
+pub async fn get_gcp_signer_from_env(resource_name: &str) -> Result<GcpSigner, Box<dyn Error>> {
     dotenvy::from_filename_override(ENV_FILE_PATH).ok();
 
     let signer = GcpSigner::new(resource_name.to_string()).await?;
     Ok(signer)
 }
 
-pub async fn run_with_retry<F, Fut>(
-    max_retries: usize,
-    operation: F,
-) -> Result<(), Box<dyn Error>>
+pub async fn run_with_retry<F, Fut>(max_retries: usize, operation: F) -> Result<(), Box<dyn Error>>
 where
     F: Fn() -> Fut,
     Fut: std::future::Future<Output = Result<(), Box<dyn Error>>>,
@@ -284,9 +255,6 @@ pub fn print_transaction_url(pre_text: &str, signature: &str) {
 
     println!(
         "\n{}: {}{}{}",
-        pre_text,
-        SOLANA_EXPLORER_URL,
-        signature,
-        cluster
+        pre_text, SOLANA_EXPLORER_URL, signature, cluster
     );
 }


### PR DESCRIPTION
Changes
- Upgrade to Solana SDK 3.0, spl-token-2022 10.0, spl-token-client 0.18
- Remove Turnkey (tk-rs) integration - will be replaced with something better later
- Fix all breaking API changes from the upgrades
- Fix deprecation warning by migrating to spl_token_2022_interface
- Default to localhost:8899 since devnet doesn't support confidential balances right now

Breaking API changes handled
- Keypair::from_bytes() → Keypair::new_from_array() (now takes 32-byte secret, not 64-byte keypair)
- ProofAccount enum removed - functions now take Option<&Pubkey> directly
- confidential_transfer_transfer_tx removed - replaced with confidential_transfer_transfer which sends internally
- Various crate reorganization (CommitmentConfig, system_instruction, etc. moved to separate crates)

Testing
basic_transfer_recipe passes on local validator. Atomic/GCP tests require external infra.