### PR TITLE
feat: Port stranded work from the archived exploration repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bs58",
+ "bytemuck",
  "chrono",
  "dotenvy",
  "env_logger",
@@ -644,6 +645,7 @@ dependencies = [
  "solana-zk-sdk 6.0.1",
  "solana-zk-sdk-pod",
  "spl-associated-token-account",
+ "spl-record",
  "spl-token-2022",
  "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
@@ -4634,6 +4636,27 @@ dependencies = [
  "quote",
  "sha2",
  "syn",
+]
+
+[[package]]
+name = "spl-record"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda0eb42ca6387770d7f0e764ecd8fa863f4529e9ff35fbf146576b5f4372587"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.1.0",
+ "solana-security-txt",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,10 +627,13 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-address 2.6.1",
+ "solana-address-lookup-table-interface",
  "solana-client",
  "solana-commitment-config",
+ "solana-compute-budget-interface",
  "solana-instruction",
  "solana-keypair",
+ "solana-message",
  "solana-native-token",
  "solana-pubkey 4.2.0",
  "solana-signature",
@@ -3121,6 +3124,16 @@ checksum = "1517aa49dcfa9cb793ef90e7aac81346d62ca4a546bb1a754030a033e3972e1c"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "solana-compute-budget-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8292c436b269ad23cecc8b24f7da3ab07ca111661e25e00ce0e1d22771951ab9"
+dependencies = [
+ "solana-instruction",
+ "solana-sdk-ids",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -36,7 +36,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1d672e0cd0e0b33ea67afae53d1a13ea6800ec51ef825e246997a072008c62"
+checksum = "33e41538180f5ded6d08a69c75b4f48c4c6ba8098d7e790b3d694a6bc081fbc7"
 dependencies = [
  "ahash",
  "solana-epoch-schedule",
@@ -67,53 +67,6 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
  "solana-svm-feature-set",
-]
-
-[[package]]
-name = "agave-transaction-view"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e6f4a1ffdf8f021fb6e5fe54f9fca7d66b2285ee2867d5f9c87067079dce6d"
-dependencies = [
- "solana-hash 4.4.0",
- "solana-message",
- "solana-packet 4.1.0",
- "solana-program-runtime",
- "solana-pubkey 4.2.0",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-signature",
- "solana-svm-transaction",
- "solana-transaction",
- "solana-transaction-context",
-]
-
-[[package]]
-name = "agave-xdp"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5073414aa9fd371a46c50925ce8d7f11d6c947aef1fb902c546e17eddd1524e2"
-dependencies = [
- "agave-xdp-ebpf",
- "arc-swap",
- "aya",
- "bytes",
- "caps",
- "core_affinity",
- "crossbeam-channel",
- "libc",
- "log",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "agave-xdp-ebpf"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1e28b67f42ed820b8dc8fac492f8e14378935b5348ed5567bf45f7288ec1f8"
-dependencies = [
- "aya",
- "aya-ebpf",
 ]
 
 [[package]]
@@ -152,12 +105,6 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -240,12 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,12 +230,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
@@ -352,7 +287,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -385,7 +320,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -396,96 +331,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "aya"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
-dependencies = [
- "assert_matches",
- "aya-obj",
- "bitflags",
- "bytes",
- "libc",
- "log",
- "object",
- "once_cell",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "aya-build"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bc42f3c5ddacc34eca28a420b47e3cbb3f0f484137cb2bf1ad2153d0eae52a"
-dependencies = [
- "anyhow",
- "cargo_metadata",
-]
-
-[[package]]
-name = "aya-ebpf"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dbaf5409a1a0982e5c9bdc0f499a55fe5ead39fe9c846012053faf0d404f73"
-dependencies = [
- "aya-ebpf-bindings",
- "aya-ebpf-cty",
- "aya-ebpf-macros",
- "rustversion",
-]
-
-[[package]]
-name = "aya-ebpf-bindings"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ee8e6a617f040d8da7565ec4010aea75e33cda4662f64c019c66ee97d17889"
-dependencies = [
- "aya-build",
- "aya-ebpf-cty",
-]
-
-[[package]]
-name = "aya-ebpf-cty"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f33396742e7fd0f519c1e0de5141d84e1a8df69146a557c08cc222b0ceace4"
-dependencies = [
- "aya-build",
-]
-
-[[package]]
-name = "aya-ebpf-macros"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fd02363736177e7e91d6c95d7effbca07be87502c7b5b32fc194aed8b177a0"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "aya-obj"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
-dependencies = [
- "bytes",
- "core-error",
- "hashbrown 0.15.5",
- "log",
- "object",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -524,36 +369,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -662,45 +483,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "caps"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -764,15 +552,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "inout",
 ]
-
-[[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -847,8 +629,14 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-client",
  "solana-commitment-config",
- "solana-sdk",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-native-token",
+ "solana-pubkey 4.2.0",
+ "solana-signature",
+ "solana-signer",
  "solana-system-interface 3.2.0",
+ "solana-transaction",
  "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk 6.0.1",
  "solana-zk-sdk-pod",
@@ -883,21 +671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "core-error"
-version = "0.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,30 +687,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core_affinity"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -986,18 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,15 +747,6 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -1027,24 +759,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rand_core 0.6.4",
  "rustc_version",
@@ -1162,21 +885,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.2",
- "ctutils",
 ]
 
 [[package]]
@@ -1191,30 +902,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "eager"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe71d579d1812060163dff96056261deb5bf6729b100fa2e36a68b9649ba3d3"
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
 
 [[package]]
 name = "ed25519"
@@ -1242,67 +956,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek-bip32"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b49a684b133c4980d7ee783936af771516011c8cd15f429dbda77245e282f03"
-dependencies = [
- "derivation-path",
- "ed25519-dalek",
- "hmac",
- "sha2",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "enum-iterator"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "env_filter"
@@ -1373,7 +1036,7 @@ dependencies = [
  "getrandom 0.3.4",
  "libm",
  "rand 0.9.4",
- "siphasher 1.0.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -1381,16 +1044,6 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -1443,12 +1096,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1555,7 +1202,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1596,17 +1242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,17 +1255,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1662,7 +1286,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1682,7 +1317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1693,7 +1328,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -1711,15 +1346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,7 +1355,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -1746,7 +1372,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1766,7 +1392,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "ipnet",
@@ -2060,13 +1686,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2086,26 +1711,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
-]
-
-[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2403,18 +2014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap",
- "memchr",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,7 +2087,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2544,7 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2604,18 +2203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
 ]
 
 [[package]]
@@ -2827,7 +2414,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2864,21 +2451,11 @@ checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 1.4.2",
  "reqwest",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -3049,20 +2626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,10 +2653,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -3209,8 +2768,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3220,8 +2779,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3236,7 +2795,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -3271,7 +2830,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3280,12 +2838,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -3321,19 +2873,6 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc0ed36decb689413b9da5d57f2be49eea5bebb3cf7897015167b0c4336e731"
 dependencies = [
- "solana-account-info",
- "solana-clock",
- "solana-instruction-error",
- "solana-pubkey 4.2.0",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-account"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c1b95bd432efb92837bc38001365e5acb5c0175b199bc447b08a8c320ecf6c"
-dependencies = [
  "bincode",
  "serde",
  "serde_bytes",
@@ -3343,14 +2882,14 @@ dependencies = [
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
- "solana-sysvar 4.0.0",
+ "solana-sysvar",
 ]
 
 [[package]]
 name = "solana-account-decoder"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8e6c1e2b6bed22e8cea7f45aa0527369f6fcfc5e776555987ed97c49cf5489"
+checksum = "5b46a77a786c876cba3faff781288ae910723433fe90090d002fbacb7fbfaa4f"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -3359,7 +2898,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.3.0",
+ "solana-account",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -3372,12 +2911,12 @@ dependencies = [
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rent 4.2.0",
+ "solana-rent 3.1.0",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stake-interface",
- "solana-sysvar 4.0.0",
+ "solana-sysvar",
  "solana-vote-interface",
  "spl-generic-token",
  "spl-token-2022-interface 2.1.0",
@@ -3390,15 +2929,15 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3971fc28a628c34d3036061b4a622f2e174252797ca14994362ec8de55e793"
+checksum = "724476642226b22fb672c90c05c4a5b6a07a7c66ad89eb54ed92244511e88581"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.3.0",
+ "solana-account",
  "solana-pubkey 4.2.0",
  "zstd",
 ]
@@ -3409,8 +2948,6 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "bincode",
- "serde_core",
  "solana-address 2.6.1",
  "solana-program-error",
  "solana-program-memory",
@@ -3437,7 +2974,6 @@ dependencies = [
  "curve25519-dalek",
  "five8",
  "five8_const",
- "rand 0.9.4",
  "serde",
  "serde_derive",
  "sha2-const-stable",
@@ -3478,28 +3014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-big-mod-exp"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "solana-define-syscall 3.0.0",
-]
-
-[[package]]
-name = "solana-blake3-hasher"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
-dependencies = [
- "blake3",
- "solana-define-syscall 4.0.1",
- "solana-hash 4.4.0",
-]
-
-[[package]]
 name = "solana-borsh"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3510,19 +3024,27 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b0a46791f7f132c0b8b1385c06b342e86f3b2f6d55667738121de2f5877b47"
+checksum = "7b4225b82e8556143ab6cf4d78243ac51a5d1670c9d168d068c667080c64bc2f"
 dependencies = [
  "async-trait",
  "bincode",
  "dashmap",
+ "futures",
  "futures-util",
+ "indexmap",
  "indicatif",
  "log",
+ "quinn",
+ "rayon",
+ "solana-account",
+ "solana-client-traits",
  "solana-commitment-config",
  "solana-connection-cache",
+ "solana-epoch-info",
  "solana-hash 4.4.0",
+ "solana-instruction",
  "solana-keypair",
  "solana-measure",
  "solana-message",
@@ -3541,27 +3063,30 @@ dependencies = [
  "solana-tpu-client",
  "solana-transaction",
  "solana-transaction-error",
+ "solana-transaction-status-client-types",
  "solana-udp-client",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "solana-client-traits"
-version = "4.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19635cc703678bcb26eb6faee4a363c71f4a0d622c445d9b70c048c42f4cbcd3"
+checksum = "08618ed587e128105510c54ae3e456b9a06d674d8640db75afe66dad65cb4e02"
 dependencies = [
- "solana-account 4.3.0",
+ "solana-account",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash 4.4.0",
+ "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 3.0.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.2.0",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -3607,7 +3132,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 3.4.0",
+ "solana-account",
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
@@ -3617,21 +3142,25 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da01adafd157818711334d1c42a60ced22b76b4f7e9e976880b0a367a8fb429"
+checksum = "0cb8be4fbbb98ad07ab3e0e6ddf55e766839b27da0952270f8fd6edda6dcb448"
 dependencies = [
  "async-trait",
+ "bincode",
  "crossbeam-channel",
+ "futures-util",
  "indexmap",
  "log",
  "rand 0.9.4",
+ "rayon",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-time-utils",
  "solana-transaction-error",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -3730,17 +3259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-epoch-rewards-hasher"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
-dependencies = [
- "siphasher 0.3.11",
- "solana-address 2.6.1",
- "solana-hash 4.4.0",
-]
-
-[[package]]
 name = "solana-epoch-schedule"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,37 +3272,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-epoch-stake"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
-dependencies = [
- "solana-define-syscall 5.1.0",
- "solana-pubkey 4.2.0",
-]
-
-[[package]]
-name = "solana-example-mocks"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb265ff95e28eceda117e2e3d2d2a611ecbbfe911dfeeeecd1521814540ffab"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash 4.4.0",
- "solana-instruction",
- "solana-nonce",
- "solana-pubkey 4.2.0",
- "solana-sdk-ids",
- "solana-system-interface 3.2.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "solana-feature-gate-interface"
-version = "4.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7545e02f91da1d6996f32b18f7796aa01e0682f8f3a7434b82cd1a10448add"
+checksum = "75ca9b5cbb6f500f7fd73db5bd95640f71a83f04d6121a0e59a43b202dca2731"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3805,22 +3296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-fee-structure"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "solana-hard-forks"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fd9cc610fd0782f09482527cb7b4f41ec22071303742718b7b57fc43bb236b"
-
-[[package]]
 name = "solana-hash"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,7 +3310,6 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe51db00ac3aa9f950d1e6201a126acfa26e6d81bc4a183ba64ec02effcad883"
 dependencies = [
- "borsh",
  "bytemuck",
  "bytemuck_derive",
  "five8",
@@ -3843,7 +3317,6 @@ dependencies = [
  "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
- "wincode",
 ]
 
 [[package]]
@@ -3851,10 +3324,6 @@ name = "solana-inflation"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f762559c5f962727efdcb03c61f5cf6c5364645695978fb145d25c88bbacdada"
-dependencies = [
- "serde",
- "serde_derive",
-]
 
 [[package]]
 name = "solana-instruction"
@@ -3863,13 +3332,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
- "borsh",
  "serde",
  "serde_derive",
  "solana-define-syscall 5.1.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
- "wincode",
 ]
 
 [[package]]
@@ -3902,30 +3369,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-keccak-hasher"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
-dependencies = [
- "sha3",
- "solana-define-syscall 4.0.1",
- "solana-hash 4.4.0",
-]
-
-[[package]]
 name = "solana-keypair"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "263d614c12aa267a3278703175fd6440552ca61bc960b5a02a4482720c53438b"
 dependencies = [
  "ed25519-dalek",
- "ed25519-dalek-bip32",
  "five8",
  "five8_core",
  "rand 0.9.4",
  "solana-address 2.6.1",
- "solana-derivation-path",
- "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
@@ -3946,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "7.0.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
+checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -3960,17 +3413,18 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f93532fa41506d02bd6b653f3baa76c6d10d356302ca97ec2f973360518929"
+checksum = "ca89d88c6b58d77cfa7f9cc746abd6a8b863131c7806b9536595e6a576632a85"
 
 [[package]]
 name = "solana-message"
-version = "4.2.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705bae842f1d02819db46ae9051613d78576c7cdabc0edb5cba4d7fe9482acaf"
+checksum = "0448b1fd891c5f46491e5dc7d9986385ba3c852c340db2911dd29faa01d2b08d"
 dependencies = [
- "blake3",
+ "bincode",
+ "lazy_static",
  "serde",
  "serde_derive",
  "solana-address 2.6.1",
@@ -3980,14 +3434,13 @@ dependencies = [
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-transaction-error",
- "wincode",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0975ac78ab19471fc749a41b79e9948d175668736badc061f208044d145d0aa"
+checksum = "e5dbcfee87e9df46779668d55db690593ae41778b036751663c1acd81e34da97"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4016,10 +3469,11 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3138db508952972afe88604097904f71c6762478808502d2f500ce72398f30"
+checksum = "02efb36551a87efe972a82f1914d7dc43e4fc271b19be75c543b3611f7b03129"
 dependencies = [
+ "anyhow",
  "bincode",
  "bytes",
  "cfg-if",
@@ -4032,7 +3486,6 @@ dependencies = [
  "socket2",
  "solana-serde",
  "solana-svm-type-overrides",
- "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -4062,31 +3515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-offchain-message"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2a1141a673f72a05cf406b99e4b2b8a457792b7c01afa07b3f00d4e2de393"
-dependencies = [
- "num_enum",
- "solana-hash 3.1.0",
- "solana-packet 3.0.0",
- "solana-pubkey 3.0.0",
- "solana-sanitize",
- "solana-sha256-hasher",
- "solana-signature",
- "solana-signer",
-]
-
-[[package]]
-name = "solana-packet"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "solana-packet"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,15 +3531,18 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b9cfc62e21bd2921956e41aef8d1c64a3ee8742a97827376855eceee59c7aa"
+checksum = "16a91d9586d63fddbbd692959c7a8f80103980182a20cc50be5faba6202f9f04"
 dependencies = [
- "agave-transaction-view",
  "ahash",
  "bincode",
+ "bv",
  "bytes",
  "caps",
+ "curve25519-dalek",
+ "dlopen2",
+ "fnv",
  "libc",
  "log",
  "nix",
@@ -4122,80 +3553,13 @@ dependencies = [
  "solana-hash 4.4.0",
  "solana-message",
  "solana-metrics",
- "solana-packet 4.1.0",
+ "solana-packet",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
  "solana-time-utils",
  "solana-transaction-context",
-]
-
-[[package]]
-name = "solana-precompile-error"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafcd950de74c6c39d55dc8ca108bbb007799842ab370ef26cf45a34453c31e1"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "solana-presigner"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f704eaf825be3180832445b9e4983b875340696e8e7239bf2d535b0f86c14a2"
-dependencies = [
- "solana-pubkey 3.0.0",
- "solana-signature",
- "solana-signer",
-]
-
-[[package]]
-name = "solana-program"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778f08fb0eaf52c9a3bef2978247f7fab0ccfddc44cfddb936d5ad9f98ede886"
-dependencies = [
- "memoffset",
- "solana-account-info",
- "solana-big-mod-exp",
- "solana-blake3-hasher",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
- "solana-define-syscall 5.1.0",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-epoch-stake",
- "solana-example-mocks",
- "solana-fee-calculator",
- "solana-hash 4.4.0",
- "solana-instruction",
- "solana-instruction-error",
- "solana-instructions-sysvar",
- "solana-keccak-hasher",
- "solana-last-restart-slot",
- "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 4.2.0",
- "solana-rent 4.2.0",
- "solana-sdk-ids",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-sha256-hasher",
- "solana-short-vec",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stable-layout",
- "solana-sysvar 4.0.0",
- "solana-sysvar-id",
 ]
 
 [[package]]
@@ -4217,8 +3581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 dependencies = [
  "borsh",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -4249,52 +3611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-program-runtime"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd91982ca350039915dd172226c96b046ba1124fc4ff99d63a2cb75fef3ef34e"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "cfg-if",
- "itertools 0.14.0",
- "log",
- "percentage",
- "rand 0.9.4",
- "serde",
- "solana-account 4.3.0",
- "solana-account-info",
- "solana-clock",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-structure",
- "solana-hash 4.4.0",
- "solana-instruction",
- "solana-last-restart-slot",
- "solana-loader-v3-interface",
- "solana-program-entrypoint",
- "solana-pubkey 4.2.0",
- "solana-rent 4.2.0",
- "solana-sbpf",
- "solana-sdk-ids",
- "solana-slot-hashes",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-svm-callback",
- "solana-svm-feature-set",
- "solana-svm-log-collector",
- "solana-svm-measure",
- "solana-svm-timings",
- "solana-svm-transaction",
- "solana-svm-type-overrides",
- "solana-system-interface 3.2.0",
- "solana-sysvar 4.0.0",
- "solana-sysvar-id",
- "solana-transaction-context",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "solana-pubkey"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4309,19 +3625,20 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
- "rand 0.9.4",
  "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "solana-pubsub-client"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d54306879778e7ff8370a018a67f46437f45d16117741676d7d73e403135fd0"
+checksum = "9a996e62922602d7a3c9abe85879994025f2ca2004e909709d30fb182325a21d"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
+ "http 0.2.12",
  "log",
+ "semver",
  "serde",
  "serde_json",
  "solana-account-decoder-client-types",
@@ -4339,15 +3656,18 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3689259c44c57b0d494d030841877ef59e9c2a8315984c9a2d4105b2be5a9ced"
+checksum = "73f41c682ec6cbabe090f15e617e53a2b31d3afd362333afd3d321c6d5f2eed2"
 dependencies = [
  "async-lock",
  "async-trait",
  "futures",
+ "itertools 0.14.0",
  "log",
  "quinn",
+ "quinn-proto",
+ "rustls",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
@@ -4382,29 +3702,24 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9809b081e99bc142ce803bcd7ee18306759ce3b30a96a9da3f6f41c45e50ef0"
 dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
  "solana-sdk-macro",
- "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-reward-info"
-version = "6.2.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc553b782111862cd6c56bdeba696dcba9722a42154ef1248c5a06ca1d983797"
+checksum = "d8f4c5c5b5599e640c15ead65be499d60f6ee62a5ba7aa7e23f5b0537046ed49"
 dependencies = [
  "serde",
  "serde_derive",
- "wincode",
 ]
 
 [[package]]
 name = "solana-rpc-client"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9641a520e9a9349b7a011a121150ad6f9147c784a84a136ee696e0a73c86c09"
+checksum = "af2bc0568e90356055b0b97efb5aa2a2559af9dce3b270fe042aa65d87955294"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4418,7 +3733,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.3.0",
+ "solana-account",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-clock",
@@ -4442,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126830dfcf2861cfdaf73def41a857cd32fc283bdd6f0f9aecb7b70f57fd8653"
+checksum = "b8a3c68bbeae45d991900fa7020ddd4a974cf2c428b28b18be0300e8526c204b"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -4452,6 +3767,7 @@ dependencies = [
  "reqwest-middleware",
  "serde",
  "serde_json",
+ "solana-account-decoder-client-types",
  "solana-clock",
  "solana-rpc-client-types",
  "solana-signer",
@@ -4462,11 +3778,11 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4838e4f4fc5fcaea10257901b021c2ce0f83581017ae7f40d8ea10002f6424f5"
+checksum = "50a24294931b9b2f891fb1f91a90830607d09058fde50f4214a3af742d00cd73"
 dependencies = [
- "solana-account 4.3.0",
+ "solana-account",
  "solana-commitment-config",
  "solana-hash 4.4.0",
  "solana-message",
@@ -4479,15 +3795,16 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7e9e4d39b1433b7228604f688bf84406d4d578864ccd2099bbdaa70a20be28"
+checksum = "174c6e2de935b0c1cf30b007a02f1e1ae4ea62f3b8101502023b372325428757"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "semver",
  "serde",
  "serde_json",
+ "solana-account",
  "solana-account-decoder-client-types",
  "solana-address 2.6.1",
  "solana-clock",
@@ -4499,6 +3816,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",
+ "spl-generic-token",
  "thiserror 2.0.18",
 ]
 
@@ -4510,56 +3828,15 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.21.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
+checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
 dependencies = [
  "byteorder",
  "combine 3.8.1",
  "hash32",
- "libc",
  "log",
- "rand 0.8.6",
  "rustc-demangle",
- "thiserror 2.0.18",
- "winapi",
-]
-
-[[package]]
-name = "solana-sdk"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657e20ea41ba32cad0c493bec60b6d55cc6c30d2c1073b94cfee96dda0d764dd"
-dependencies = [
- "bincode",
- "bs58",
- "serde",
- "solana-account 4.3.0",
- "solana-epoch-info",
- "solana-epoch-rewards-hasher",
- "solana-fee-structure",
- "solana-inflation",
- "solana-keypair",
- "solana-message",
- "solana-offchain-message",
- "solana-presigner",
- "solana-program",
- "solana-program-memory",
- "solana-pubkey 4.2.0",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-serde",
- "solana-serde-varint",
- "solana-short-vec",
- "solana-shred-version",
- "solana-signature",
- "solana-signer",
- "solana-time-utils",
- "solana-transaction",
- "solana-transaction-error",
  "thiserror 2.0.18",
 ]
 
@@ -4582,17 +3859,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "solana-secp256k1-recover"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
-dependencies = [
- "k256",
- "solana-define-syscall 5.1.0",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4668,18 +3934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8250a4495aad49ad20556a607da53bdcb20de78da10b65afbf918b7f1de647"
 dependencies = [
  "serde_core",
- "wincode",
-]
-
-[[package]]
-name = "solana-shred-version"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c79722e299d957958bf33695f7cd1ef6724ff55563c60fd9e3e24487cccde2"
-dependencies = [
- "solana-hard-forks",
- "solana-hash 4.4.0",
- "solana-sha256-hasher",
 ]
 
 [[package]]
@@ -4690,7 +3944,6 @@ checksum = "b0364c7577c3c82a693ce28a1febc8d1b5d1b0a175fdc2114ae6186b69effe1e"
 dependencies = [
  "ed25519-dalek",
  "five8",
- "rand 0.9.4",
  "serde",
  "serde-big-array",
  "serde_derive",
@@ -4747,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.1.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
+checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
 dependencies = [
  "num-traits",
  "serde",
@@ -4758,22 +4011,24 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
- "solana-system-interface 3.2.0",
- "solana-sysvar 4.0.0",
+ "solana-pubkey 3.0.0",
+ "solana-system-interface 2.0.0",
+ "solana-sysvar",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d429cd1395305e30b28d4e151ae8d5a1a5afeef7e76c501548058ed0197cee6"
+checksum = "85a799bdc87cc4c58d2f997e4689956da8a769a9cc17fd3f4e91abd043b828e1"
 dependencies = [
- "agave-xdp",
+ "arc-swap",
  "bytes",
  "crossbeam-channel",
+ "dashmap",
  "futures",
+ "futures-util",
  "histogram",
  "indexmap",
  "itertools 0.14.0",
@@ -4784,87 +4039,41 @@ dependencies = [
  "pem",
  "percentage",
  "quinn",
+ "quinn-proto",
  "rand 0.9.4",
  "rustls",
  "smallvec",
+ "socket2",
  "solana-keypair",
+ "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-packet 4.1.0",
+ "solana-packet",
  "solana-perf",
  "solana-pubkey 4.2.0",
+ "solana-signature",
  "solana-signer",
  "solana-time-utils",
  "solana-tls-utils",
  "solana-transaction-error",
+ "solana-transaction-metrics-tracker",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "solana-svm-callback"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "096428522c522e04d189170bced59943e97f0660cafe5dc09dfbeb1f2d9d293a"
-dependencies = [
- "solana-account 4.3.0",
- "solana-clock",
- "solana-precompile-error",
- "solana-pubkey 4.2.0",
+ "x509-parser",
 ]
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a039f09ec29dddcbb6797dfa6607d9d79c3d47274030bcec2da693bfb6a9e4da"
-
-[[package]]
-name = "solana-svm-log-collector"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964ba8077817adf4963933c930ec900c69e0e6c16cfb8e309cfe6578d9c3037e"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "solana-svm-measure"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df94b437896bdcf4370655ca93e39ebf1d0bd2564d73c9de0ff3162ea5b08c3"
-
-[[package]]
-name = "solana-svm-timings"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3129d2c7d48e8a25d13f40af020a2525e6f43787d41c3bbef7e3ef7e78cd50e"
-dependencies = [
- "eager",
- "enum-iterator",
- "solana-pubkey 4.2.0",
-]
-
-[[package]]
-name = "solana-svm-transaction"
-version = "4.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0f6df62bfb33980877e14264aed1ca30f61b3d659f906329c4340c81815457"
-dependencies = [
- "solana-hash 4.4.0",
- "solana-message",
- "solana-pubkey 4.2.0",
- "solana-sdk-ids",
- "solana-signature",
- "solana-transaction",
-]
+checksum = "3ada78631678a5a5139d6491bb8729143192c6afd30945dd8cddd974b174d7f7"
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb09669f9104909d7092aca546346c061bbab9cd4302393a99d593f13faeb4b8"
+checksum = "da24176c92931464ac3dae45b8be137bf747f838d022f41728405f958c63e32d"
 dependencies = [
  "rand 0.9.4",
 ]
@@ -4897,7 +4106,6 @@ dependencies = [
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
- "wincode",
 ]
 
 [[package]]
@@ -4933,40 +4141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sysvar"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1632b69b4f72489db5949a10e8308c229dfa003f99ecaa7477b376807c7b81f4"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall 5.1.0",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash 4.4.0",
- "solana-instruction",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey 4.2.0",
- "solana-rent 4.2.0",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-sysvar-id",
-]
-
-[[package]]
 name = "solana-sysvar-id"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4984,9 +4158,9 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dee651967d49f172df6739a8afb6de5a2b74e07418dff5cb9e0cdc23d893d2"
+checksum = "859675b0e1dcd48f79982bfe24f50bbac94c4d7d34429afb14db219bc3ee510c"
 dependencies = [
  "rustls",
  "solana-keypair",
@@ -4997,11 +4171,14 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd28e07f76f322fdafca127784e038446126b42e7d918c9849aff63972f1c2f"
+checksum = "9f06184c4dc677c14c9cac20b4f301409190a3c3a0c0485fd40101f25eabe64f"
 dependencies = [
+ "async-trait",
+ "bincode",
  "futures-util",
+ "indexmap",
  "indicatif",
  "log",
  "rayon",
@@ -5010,7 +4187,9 @@ dependencies = [
  "solana-commitment-config",
  "solana-connection-cache",
  "solana-epoch-schedule",
+ "solana-measure",
  "solana-message",
+ "solana-net-utils",
  "solana-pubkey 4.2.0",
  "solana-pubsub-client",
  "solana-rpc-client",
@@ -5021,15 +4200,15 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.18",
  "tokio",
- "wincode",
 ]
 
 [[package]]
 name = "solana-transaction"
-version = "4.1.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d105ecce084206697230226c6b2230401c220feb4dc63e1274d58b38969292"
+checksum = "96697cff5075a028265324255efed226099f6d761ca67342b230d09f72cc48d2"
 dependencies = [
+ "bincode",
  "serde",
  "serde_derive",
  "solana-address 2.6.1",
@@ -5043,22 +4222,21 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-transaction-error",
- "wincode",
 ]
 
 [[package]]
 name = "solana-transaction-context"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12f1cbf59ffe3ca310520f1b53fe52f0846f17ae51b29b666b031563633cfaf"
+checksum = "9ee065d9e0a7d374c012d541083b1e72832a7f016ac2ab493f535d07fa89c26d"
 dependencies = [
  "bincode",
  "serde",
- "solana-account 4.3.0",
+ "solana-account",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-pubkey 4.2.0",
- "solana-rent 4.2.0",
+ "solana-rent 3.1.0",
  "solana-sbpf",
  "solana-sdk-ids",
 ]
@@ -5076,10 +4254,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-transaction-status-client-types"
-version = "4.1.0-beta.3"
+name = "solana-transaction-metrics-tracker"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1939900b1f7fae73a3acff99308509380d054ee33f7955d8a3d874f643f2891e"
+checksum = "d6943c2fff4d2e9e8fc2cca38fefdcfb83f3f04b38b8227ac046fb55f80f1d30"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "log",
+ "rand 0.9.4",
+ "solana-packet",
+ "solana-perf",
+ "solana-short-vec",
+ "solana-signature",
+]
+
+[[package]]
+name = "solana-transaction-status-client-types"
+version = "4.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14125d6b1dffa49b12adea3b763eff35ab83ad2aaff27dacee6ea2c9068a3256"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5090,20 +4284,20 @@ dependencies = [
  "solana-commitment-config",
  "solana-instruction",
  "solana-message",
+ "solana-pubkey 4.2.0",
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "wincode",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060202c42452c40ffb54b120971d55f85fc52db2933a53c9398b803915329057"
+checksum = "106027a8280a04aecc2b70076ff2cacf9334370014f1763ad495afb1197fa774"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -5111,13 +4305,15 @@ dependencies = [
  "solana-net-utils",
  "solana-streamer",
  "solana-transaction-error",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
 name = "solana-version"
-version = "4.1.0-beta.3"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de9e9589e411fdb7c1f038b0678de0ac0725b21b179b7ab827efcc9eb63432e"
+checksum = "05a72745825b1cf786bfd14024a0f52e15b5b95c7eb58152af6608804cd0fa95"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.4",
@@ -5129,9 +4325,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "6.0.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d495cb001d3373229ba523625783e5168707f70a9c38ddc90fbc5b0470d600ea"
+checksum = "d444ce30b6b4f9c281ba06061ea96638d063b53c2171b1e41ba02ebff79ed28f"
 dependencies = [
  "bincode",
  "cfg_eval",
@@ -5290,7 +4486,7 @@ dependencies = [
  "solana-rent 3.1.0",
  "solana-sdk-ids",
  "solana-system-interface 2.0.0",
- "solana-sysvar 3.1.1",
+ "solana-sysvar",
  "spl-associated-token-account-interface",
  "spl-token-2022-interface 2.1.0",
  "spl-token-interface",
@@ -5472,7 +4668,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-security-txt",
  "solana-system-interface 3.2.0",
- "solana-sysvar 3.1.1",
+ "solana-sysvar",
  "solana-zero-copy",
  "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk-pod",
@@ -6031,7 +5227,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "pin-project-lite",
@@ -6132,7 +5328,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -6174,7 +5370,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
 ]
 
@@ -6287,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6300,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6310,9 +5506,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6320,9 +5516,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6333,18 +5529,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -36,7 +36,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -56,27 +56,64 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0d37e3232be339a6a19a376c7696458b6a8183e95bf806709fad71595010b"
+checksum = "aa1d672e0cd0e0b33ea67afae53d1a13ea6800ec51ef825e246997a072008c62"
 dependencies = [
  "ahash",
  "solana-epoch-schedule",
- "solana-hash 3.1.0",
- "solana-pubkey 3.0.0",
+ "solana-hash 4.4.0",
+ "solana-keypair",
+ "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
  "solana-svm-feature-set",
 ]
 
 [[package]]
-name = "agave-reserved-account-keys"
-version = "3.1.6"
+name = "agave-transaction-view"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c651f94dc123e67cacfcf320b686aaaf8daf7910a263982ab806fe50ae197eb0"
+checksum = "52e6f4a1ffdf8f021fb6e5fe54f9fca7d66b2285ee2867d5f9c87067079dce6d"
 dependencies = [
- "agave-feature-set",
- "solana-pubkey 3.0.0",
+ "solana-hash 4.4.0",
+ "solana-message",
+ "solana-packet 4.1.0",
+ "solana-program-runtime",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-signature",
+ "solana-svm-transaction",
+ "solana-transaction",
+ "solana-transaction-context",
+]
+
+[[package]]
+name = "agave-xdp"
+version = "4.1.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5073414aa9fd371a46c50925ce8d7f11d6c947aef1fb902c546e17eddd1524e2"
+dependencies = [
+ "agave-xdp-ebpf",
+ "arc-swap",
+ "aya",
+ "bytes",
+ "caps",
+ "core_affinity",
+ "crossbeam-channel",
+ "libc",
+ "log",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "agave-xdp-ebpf"
+version = "4.1.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1e28b67f42ed820b8dc8fac492f8e14378935b5348ed5567bf45f7288ec1f8"
+dependencies = [
+ "aya",
+ "aya-ebpf",
 ]
 
 [[package]]
@@ -132,19 +169,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -157,15 +185,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -192,15 +220,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -225,9 +253,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -235,38 +263,44 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
 name = "asn1-rs-impl"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.4.37"
+name = "assert_matches"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -293,7 +327,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -303,21 +337,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -329,7 +352,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -362,7 +385,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -372,6 +395,90 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags",
+ "bytes",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aya-build"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bc42f3c5ddacc34eca28a420b47e3cbb3f0f484137cb2bf1ad2153d0eae52a"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+]
+
+[[package]]
+name = "aya-ebpf"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dbaf5409a1a0982e5c9bdc0f499a55fe5ead39fe9c846012053faf0d404f73"
+dependencies = [
+ "aya-ebpf-bindings",
+ "aya-ebpf-cty",
+ "aya-ebpf-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "aya-ebpf-bindings"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ee8e6a617f040d8da7565ec4010aea75e33cda4662f64c019c66ee97d17889"
+dependencies = [
+ "aya-build",
+ "aya-ebpf-cty",
+]
+
+[[package]]
+name = "aya-ebpf-cty"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f33396742e7fd0f519c1e0de5141d84e1a8df69146a557c08cc222b0ceace4"
+dependencies = [
+ "aya-build",
+]
+
+[[package]]
+name = "aya-ebpf-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fd02363736177e7e91d6c95d7effbca07be87502c7b5b32fc194aed8b177a0"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.5",
+ "log",
+ "object",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -409,44 +516,26 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -459,61 +548,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "blst"
-version = "0.3.16"
+name = "block-buffer"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "cc",
- "glob",
- "threadpool",
- "zeroize",
-]
-
-[[package]]
-name = "blstrs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
-dependencies = [
- "blst",
- "byte-slice-cast",
- "ff",
- "group",
- "pairing",
- "rand_core 0.6.4",
- "serde",
- "subtle",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -522,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -541,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bv"
@@ -554,12 +625,6 @@ dependencies = [
  "feature-probe",
  "serde",
 ]
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -578,7 +643,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -589,11 +654,20 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -606,10 +680,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.52"
+name = "cargo-platform"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -643,14 +741,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -666,30 +764,21 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width 0.1.14",
- "vec_map",
-]
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -716,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.36"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -728,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -748,7 +837,6 @@ dependencies = [
  "anyhow",
  "axum",
  "bs58",
- "bytemuck",
  "chrono",
  "dotenvy",
  "env_logger",
@@ -756,20 +844,17 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
  "solana-client",
  "solana-commitment-config",
  "solana-sdk",
- "solana-system-interface 3.0.0",
- "solana-system-program",
+ "solana-system-interface 3.2.0",
  "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk 6.0.1",
  "solana-zk-sdk-pod",
  "spl-associated-token-account",
- "spl-record",
  "spl-token-2022",
- "spl-token-client",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
  "tokio",
  "tokio-stream",
@@ -781,27 +866,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "unicode-width 0.2.2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -816,6 +887,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -834,10 +914,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -909,6 +1009,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,15 +1027,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rand_core 0.6.4",
  "rustc_version",
@@ -943,14 +1061,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -958,27 +1076,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
- "syn 2.0.117",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -996,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1012,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1026,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1040,82 +1157,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
 
 [[package]]
-name = "dialoguer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
-dependencies = [
- "console 0.15.11",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
-dependencies = [
- "dlopen2_derive",
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1137,7 +1209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1183,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1195,7 +1267,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1214,9 +1286,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-iterator"
-version = "1.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -1229,14 +1301,14 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -1244,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1300,15 +1372,9 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
- "siphasher 1.0.1",
+ "rand 0.9.4",
+ "siphasher 1.0.3",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "feature-probe"
@@ -1322,7 +1388,6 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1335,18 +1400,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
-
-[[package]]
-name = "five8"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75b8549488b4715defcb0d8a8a1c1c76a80661b5fa106b4ca0e7fce59d7d875"
-dependencies = [
- "five8_core 0.1.2",
-]
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "five8"
@@ -1354,7 +1410,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 1.0.0",
+ "five8_core",
 ]
 
 [[package]]
@@ -1363,14 +1419,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 1.0.0",
+ "five8_core",
 ]
-
-[[package]]
-name = "five8_core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
 name = "five8_core"
@@ -1380,9 +1430,9 @@ checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1410,16 +1460,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1432,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1442,15 +1486,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1459,44 +1503,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1506,7 +1544,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1523,12 +1560,12 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.2.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -1559,41 +1596,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "governor"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures",
- "futures-timer",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.8.5",
- "smallvec",
- "spinning_top",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.8.5",
  "rand_core 0.6.4",
- "rand_xorshift",
  "subtle",
 ]
 
@@ -1614,9 +1623,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1625,18 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hermit-abi"
@@ -1662,25 +1662,14 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1693,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1704,7 +1693,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -1722,28 +1711,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.4.0",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1751,33 +1742,31 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "hyper",
  "ipnet",
@@ -1792,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1816,12 +1805,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1829,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1842,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1856,15 +1846,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1876,15 +1866,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1914,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1924,23 +1914,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.2",
+ "console",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width",
  "unit-prefix",
  "web-time",
 ]
@@ -1956,19 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1996,15 +1976,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -2015,13 +1995,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2033,7 +2013,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine 4.6.7",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2042,9 +2022,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2058,10 +2060,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2097,11 +2101,11 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2112,37 +2116,27 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
-]
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2155,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -2182,9 +2176,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -2231,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2242,22 +2236,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
 ]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"
@@ -2268,12 +2256,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2331,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2343,7 +2325,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2385,6 +2367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2393,15 +2376,15 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -2409,30 +2392,42 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2448,18 +2443,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
-
-[[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group",
-]
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking"
@@ -2492,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pbkdf2"
@@ -2502,17 +2488,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2541,15 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -2563,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
@@ -2574,31 +2544,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2619,16 +2589,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty-hex"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
-
-[[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -2643,27 +2607,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -2677,7 +2638,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2688,17 +2649,17 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2739,16 +2700,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2757,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2804,28 +2759,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2847,25 +2784,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2875,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2886,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2901,7 +2827,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2927,7 +2853,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2938,7 +2864,7 @@ checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.0",
+ "http",
  "reqwest",
  "serde",
  "thiserror 1.0.69",
@@ -2970,27 +2896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpassword"
-version = "7.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,15 +2903,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3028,11 +2927,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3041,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -3055,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3067,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3104,9 +3003,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3121,9 +3020,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3136,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3165,11 +3064,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3178,9 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3188,9 +3087,13 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -3238,14 +3141,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3279,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -3289,27 +3192,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "syn",
 ]
 
 [[package]]
@@ -3319,8 +3209,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3330,8 +3220,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3342,11 +3232,11 @@ checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -3360,16 +3250,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3387,15 +3271,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -3405,15 +3289,15 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3423,19 +3307,32 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "solana-account"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e0ac2a81ae17e1b3570deb50242ab4cfde50b848b898f57288b6271cc7b71f"
+checksum = "efc0ed36decb689413b9da5d57f2be49eea5bebb3cf7897015167b0c4336e731"
+dependencies = [
+ "solana-account-info",
+ "solana-clock",
+ "solana-instruction-error",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-account"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c1b95bd432efb92837bc38001365e5acb5c0175b199bc447b08a8c320ecf6c"
 dependencies = [
  "bincode",
  "serde",
@@ -3444,16 +3341,16 @@ dependencies = [
  "solana-account-info",
  "solana-clock",
  "solana-instruction-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
- "solana-sysvar",
+ "solana-sysvar 4.0.0",
 ]
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2743ab6d07e8261a2066d9f118a566a9c4c2143629a3c3d0a7dc58c3d37b659f"
+checksum = "1a8e6c1e2b6bed22e8cea7f45aa0527369f6fcfc5e776555987ed97c49cf5489"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -3462,7 +3359,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account",
+ "solana-account 4.3.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -3474,47 +3371,47 @@ dependencies = [
  "solana-nonce",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.0",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stake-interface",
- "solana-sysvar",
+ "solana-sysvar 4.0.0",
  "solana-vote-interface",
  "spl-generic-token",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "spl-token-group-interface",
  "spl-token-interface",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.8.0",
  "thiserror 2.0.18",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903d72faba9acbb483b35e00d5c84e4245367336410553fc4d1f216219283724"
+checksum = "aa3971fc28a628c34d3036061b4a622f2e174252797ca14994362ec8de55e793"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "serde",
  "serde_json",
- "solana-account",
- "solana-pubkey 3.0.0",
+ "solana-account 4.3.0",
+ "solana-pubkey 4.2.0",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-info"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
+checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
  "bincode",
  "serde_core",
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -3525,27 +3422,28 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
 dependencies = [
  "borsh",
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek",
- "five8 1.0.0",
+ "five8",
  "five8_const",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
  "solana-define-syscall 5.1.0",
+ "solana-nullable",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -3554,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-interface"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8df0b083c10ce32490410f3795016b1b5d9b4d094658c0a5e496753645b7cd"
+checksum = "115b4f773acc4f3f3cb986b0d335e9845c0368c82b0940410935bc11ae065578"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3565,16 +3463,16 @@ dependencies = [
  "solana-clock",
  "solana-instruction",
  "solana-instruction-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-slot-hashes",
 ]
 
 [[package]]
 name = "solana-atomic-u64"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a933ff1e50aff72d02173cfcd7511bd8540b027ee720b75f353f594f834216d0"
+checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
 dependencies = [
  "parking_lot",
 ]
@@ -3591,17 +3489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bincode"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278a1a5bad62cd9da89ac8d4b7ec444e83caa8ae96aa656dfc27684b28d49a5d"
-dependencies = [
- "bincode",
- "serde_core",
- "solana-instruction-error",
-]
-
-[[package]]
 name = "solana-blake3-hasher"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,155 +3496,40 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.0.1",
-]
-
-[[package]]
-name = "solana-bls-signatures"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c75573697bbb148afa8209aa3ce228ca0754584c9a8a91e818db0f706ae4fb"
-dependencies = [
- "base64 0.22.1",
- "blst",
- "blstrs",
- "cfg_eval",
- "ff",
- "group",
- "pairing",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
+ "solana-hash 4.4.0",
 ]
 
 [[package]]
 name = "solana-borsh"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc402b16657abbfa9991cd5cbfac5a11d809f7e7d28d3bb291baeb088b39060e"
+checksum = "c04abbae16f57178a163125805637b8a076175bb5c0002fb04f4792bea901cf7"
 dependencies = [
  "borsh",
 ]
 
 [[package]]
-name = "solana-clap-utils"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02ceca9a77472dc6ad4e0d54ca83501b724985c16768c9d8b26e5f358111483"
-dependencies = [
- "chrono",
- "clap",
- "rpassword",
- "solana-bls-signatures",
- "solana-clock",
- "solana-cluster-type",
- "solana-commitment-config",
- "solana-derivation-path",
- "solana-hash 3.1.0",
- "solana-keypair",
- "solana-message",
- "solana-native-token",
- "solana-presigner",
- "solana-pubkey 3.0.0",
- "solana-remote-wallet",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
- "thiserror 2.0.18",
- "tiny-bip39",
- "uriparse",
- "url",
-]
-
-[[package]]
-name = "solana-cli-config"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8529cdbcb608841490d2f66a66617e991efcb8acbfaa038fd154a6685348f"
-dependencies = [
- "dirs-next",
- "serde",
- "serde_yaml",
- "solana-clap-utils",
- "solana-commitment-config",
- "url",
-]
-
-[[package]]
-name = "solana-cli-output"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7eaf400ee406e0361b6b86cf680b570cc120c1d646bd6c135a6f75d291a1a2b"
-dependencies = [
- "Inflector",
- "agave-reserved-account-keys",
- "base64 0.22.1",
- "chrono",
- "clap",
- "console 0.16.2",
- "humantime",
- "indicatif",
- "pretty-hex",
- "semver",
- "serde",
- "serde_json",
- "solana-account",
- "solana-account-decoder",
- "solana-bincode",
- "solana-clap-utils",
- "solana-cli-config",
- "solana-clock",
- "solana-epoch-info",
- "solana-hash 3.1.0",
- "solana-message",
- "solana-packet",
- "solana-pubkey 3.0.0",
- "solana-rpc-client-api",
- "solana-sdk-ids",
- "solana-signature",
- "solana-stake-interface",
- "solana-system-interface 2.0.0",
- "solana-transaction",
- "solana-transaction-error",
- "solana-transaction-status",
- "solana-transaction-status-client-types",
- "solana-vote-program",
- "spl-memo-interface",
-]
-
-[[package]]
 name = "solana-client"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee8a02f1f8646d456d75a0ca3aa3c8aee3e06b1f22a5b25dfcbdc8d87855aa5"
+checksum = "72b0a46791f7f132c0b8b1385c06b342e86f3b2f6d55667738121de2f5877b47"
 dependencies = [
  "async-trait",
  "bincode",
  "dashmap",
- "futures",
  "futures-util",
- "indexmap",
  "indicatif",
  "log",
- "quinn",
- "rayon",
- "solana-account",
- "solana-client-traits",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-epoch-info",
- "solana-hash 3.1.0",
- "solana-instruction",
+ "solana-hash 4.4.0",
  "solana-keypair",
  "solana-measure",
  "solana-message",
  "solana-net-utils",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-pubsub-client",
  "solana-quic-client",
- "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-rpc-client-nonce-utils",
@@ -3765,42 +3537,40 @@ dependencies = [
  "solana-signer",
  "solana-streamer",
  "solana-time-utils",
+ "solana-tls-utils",
  "solana-tpu-client",
  "solana-transaction",
  "solana-transaction-error",
- "solana-transaction-status-client-types",
  "solana-udp-client",
- "thiserror 2.0.18",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
 name = "solana-client-traits"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08618ed587e128105510c54ae3e456b9a06d674d8640db75afe66dad65cb4e02"
+checksum = "19635cc703678bcb26eb6faee4a363c71f4a0d622c445d9b70c048c42f4cbcd3"
 dependencies = [
- "solana-account",
+ "solana-account 4.3.0",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
 
 [[package]]
 name = "solana-clock"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb62e9381182459a4520b5fe7fb22d423cae736239a6427fc398a88743d0ed59"
+checksum = "5ea35d8f69b67daddb921a9da7f78ca591b533cf5e98833cd9ae62fdc2e4652c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3811,31 +3581,21 @@ dependencies = [
 
 [[package]]
 name = "solana-cluster-type"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7692fa6bf10a1a86b450c4775526f56d7e0e2116a53313f2533b5694abea64"
+checksum = "3a494cf8eda7d98d9f0144b288bb409c88308d2e86f15cc1045aa77b83304718"
 dependencies = [
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
 ]
 
 [[package]]
 name = "solana-commitment-config"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e41a3917076a8b5375809078ae3a6fb76a53e364b596ef8c4265e7f410876f3"
+checksum = "1517aa49dcfa9cb793ef90e7aac81346d62ca4a546bb1a754030a033e3972e1c"
 dependencies = [
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "solana-compute-budget-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8292c436b269ad23cecc8b24f7da3ab07ca111661e25e00ce0e1d22771951ab9"
-dependencies = [
- "solana-instruction",
- "solana-sdk-ids",
 ]
 
 [[package]]
@@ -3847,7 +3607,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account",
+ "solana-account 3.4.0",
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
@@ -3857,25 +3617,21 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97904fc33d6ac88fe4012f631bd0a7674e5cdda22934930844e99618a140efdc"
+checksum = "1da01adafd157818711334d1c42a60ced22b76b4f7e9e976880b0a367a8fb429"
 dependencies = [
  "async-trait",
- "bincode",
  "crossbeam-channel",
- "futures-util",
  "indexmap",
  "log",
- "rand 0.8.5",
- "rayon",
+ "rand 0.9.4",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-time-utils",
  "solana-transaction-error",
  "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]
@@ -3888,20 +3644,34 @@ dependencies = [
  "solana-define-syscall 4.0.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-stable-layout",
 ]
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.6"
+version = "3.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7012a457fa158f4b0e7160add8d3882536177a2e4942be5c993f7bff65edbec"
+checksum = "5aff7432cdf2ec6a44ac06b4d64d2ee006f6c0066d6456e032a7fe25be40cd5c"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek",
  "solana-define-syscall 3.0.0",
+ "subtle",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-curve25519"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b4d2a4bf0d0b0a86c22111917e86e8bd39a7b31420fb2c7d73eb83761fc7af"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek",
+ "solana-define-syscall 5.1.0",
  "subtle",
  "thiserror 2.0.18",
 ]
@@ -3947,13 +3717,13 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-rewards"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b319a4ed70390af911090c020571f0ff1f4ec432522d05ab89f5c08080381995"
+checksum = "1cddf2388b28291210d9aa60690740733cab527531f06ed153c4d388951e407c"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -3966,15 +3736,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
 dependencies = [
  "siphasher 0.3.11",
- "solana-address 2.6.0",
- "solana-hash 4.0.1",
+ "solana-address 2.6.1",
+ "solana-hash 4.4.0",
 ]
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
+checksum = "9ce264b7b42322325947c4136a09460bf5c73d9aa8262c9b0a2064be63ba8639"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3985,53 +3755,49 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-stake"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc6693d0ea833b880514b9b88d95afb80b42762dca98b0712465d1fcbbcb89e"
+checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
 dependencies = [
- "solana-define-syscall 3.0.0",
- "solana-pubkey 3.0.0",
+ "solana-define-syscall 5.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-example-mocks"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978855d164845c1b0235d4b4d101cadc55373fffaf0b5b6cfa2194d25b2ed658"
+checksum = "0eb265ff95e28eceda117e2e3d2d2a611ecbbfe911dfeeeecd1521814540ffab"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-instruction",
- "solana-keccak-hasher",
- "solana-message",
  "solana-nonce",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "solana-feature-gate-interface"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347ab62e6d47a82e340c865133795b394feea7c2b2771d293f57691c6544c3f"
+checksum = "bd7545e02f91da1d6996f32b18f7796aa01e0682f8f3a7434b82cd1a10448add"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
 ]
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.0.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a73cc03ca4bed871ca174558108835f8323e85917bb38b9c81c7af2ab853efe"
+checksum = "97ee18959f176ba6229105c6c2a2ddaaa04bd53615af9277d834b113571bd205"
 dependencies = [
  "log",
  "serde",
@@ -4050,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "solana-hard-forks"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abacc4b66ce471f135f48f22facf75cbbb0f8a252fbe2c1e0aa59d5b203f519"
+checksum = "52fd9cc610fd0782f09482527cb7b4f41ec22071303742718b7b57fc43bb236b"
 
 [[package]]
 name = "solana-hash"
@@ -4060,30 +3826,31 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
 dependencies = [
- "solana-hash 4.0.1",
+ "solana-hash 4.4.0",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "4.0.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5d48a6ee7b91fc7b998944ab026ed7b3e2fc8ee3bc58452644a86c2648152f"
+checksum = "fe51db00ac3aa9f950d1e6201a126acfa26e6d81bc4a183ba64ec02effcad883"
 dependencies = [
  "borsh",
  "bytemuck",
  "bytemuck_derive",
- "five8 1.0.0",
+ "five8",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-inflation"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92f37a14e7c660628752833250dd3dcd8e95309876aee751d7f8769a27947c6"
+checksum = "f762559c5f962727efdcb03c61f5cf6c5364645695978fb145d25c88bbacdada"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4091,24 +3858,25 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.1.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
  "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "solana-instruction-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04259e03c05faf38a8c24217b5cfe4c90572ae6184ab49cddb1584fdd756d3f"
+checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
 dependencies = [
  "num-traits",
  "serde",
@@ -4118,16 +3886,15 @@ dependencies = [
 
 [[package]]
 name = "solana-instructions-sysvar"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
+checksum = "9e0732294560e88ecdb2bbc656e67383e9f88c78ec09469cef172f0d28cd1bcd"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "solana-account-info",
  "solana-instruction",
  "solana-instruction-error",
  "solana-program-error",
- "solana-pubkey 3.0.0",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-serialize-utils",
@@ -4142,20 +3909,21 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.0.1",
+ "solana-hash 4.4.0",
 ]
 
 [[package]]
 name = "solana-keypair"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8be597c9e231b0cab2928ce3bc3e4ee77d9c0ad92977b9d901f3879f25a7a"
+checksum = "263d614c12aa267a3278703175fd6440552ca61bc960b5a02a4482720c53438b"
 dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
- "five8 1.0.0",
- "rand 0.8.5",
- "solana-address 2.6.0",
+ "five8",
+ "five8_core",
+ "rand 0.9.4",
+ "solana-address 2.6.1",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -4165,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcda154ec827f5fc1e4da0af3417951b7e9b8157540f81f936c4a8b1156134d0"
+checksum = "426711c6564b790026e45cabec3c64b971864c48b6b2d83c0ebf52a118bb4cda"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4177,65 +3945,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-loader-v2-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4a6f0ad4fd9c30679bfee2ce3ea6a449cac38049f210480b751f65676dfe82"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-loader-v3-interface"
-version = "6.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee44c9b1328c5c712c68966fb8de07b47f3e7bac006e74ddd1bb053d3e46e5d"
+checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
 dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
- "solana-system-interface 2.0.0",
 ]
 
 [[package]]
 name = "solana-measure"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef687aac555fa8ab56f1fff63be6902c484784344ce195653bd840a3d19462be"
+checksum = "a8f93532fa41506d02bd6b653f3baa76c6d10d356302ca97ec2f973360518929"
 
 [[package]]
 name = "solana-message"
-version = "3.0.1"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85666605c9fd727f865ed381665db0a8fc29f984a030ecc1e40f43bfb2541623"
+checksum = "705bae842f1d02819db46ae9051613d78576c7cdabc0edb5cba4d7fe9482acaf"
 dependencies = [
- "bincode",
  "blake3",
- "lazy_static",
  "serde",
  "serde_derive",
- "solana-address 1.1.0",
- "solana-hash 3.1.0",
+ "solana-address 2.6.1",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3595ded6be33832d82c75d3bcae1018f48635b3ec47578d275c807ab1cb565"
+checksum = "a0975ac78ab19471fc749a41b79e9948d175668736badc061f208044d145d0aa"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4249,11 +4001,11 @@ dependencies = [
 
 [[package]]
 name = "solana-msg"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
+checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall 5.1.0",
 ]
 
 [[package]]
@@ -4264,58 +4016,50 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54820b244f1bc56514cf02232453046ea537c9e590478962e976a62162f17915"
+checksum = "ab3138db508952972afe88604097904f71c6762478808502d2f500ce72398f30"
 dependencies = [
- "anyhow",
  "bincode",
  "bytes",
  "cfg-if",
  "dashmap",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "nix",
- "rand 0.8.5",
+ "rand 0.9.4",
  "serde",
  "socket2",
  "solana-serde",
  "solana-svm-type-overrides",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "solana-nonce"
-version = "3.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbdc6c8caf1c08db9f36a50967539d0f72b9f1d4aea04fec5430f532e5afadc"
+checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-hash 3.1.0",
- "solana-pubkey 3.0.0",
+ "solana-hash 4.4.0",
+ "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
-name = "solana-nonce-account"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805fd25b29e5a1a0e6c3dd6320c9da80f275fbe4ff6e392617c303a2085c435e"
-dependencies = [
- "solana-account",
- "solana-hash 3.1.0",
- "solana-nonce",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-nullable"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da028344c595c7416769ff648d206de7962571291a4cea24c38a60b6f40d53bb"
+checksum = "a0f95d3028ef0f682bb174b77379c19d5dae2904a649f4a103fe29be7a139980"
+dependencies = [
+ "borsh",
+ "bytemuck",
+]
 
 [[package]]
 name = "solana-offchain-message"
@@ -4325,7 +4069,7 @@ checksum = "f6e2a1141a673f72a05cf406b99e4b2b8a457792b7c01afa07b3f00d4e2de393"
 dependencies = [
  "num_enum",
  "solana-hash 3.1.0",
- "solana-packet",
+ "solana-packet 3.0.0",
  "solana-pubkey 3.0.0",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -4339,40 +4083,47 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
 dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "solana-packet"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad62e1045c2347a0c0e219a6ceb0abfe904be622920996bfcac8d116fabe3c7"
+dependencies = [
  "bincode",
- "bitflags 2.10.0",
+ "bitflags",
  "cfg_eval",
  "serde",
  "serde_derive",
  "serde_with",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-perf"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ce50c6e8de8616805c3e7b327289288bdb3385b309ec197ddd5fa05ba16780"
+checksum = "e9b9cfc62e21bd2921956e41aef8d1c64a3ee8742a97827376855eceee59c7aa"
 dependencies = [
+ "agave-transaction-view",
  "ahash",
  "bincode",
- "bv",
  "bytes",
  "caps",
- "curve25519-dalek",
- "dlopen2",
- "fnv",
  "libc",
  "log",
  "nix",
- "rand 0.8.5",
+ "num_cpus",
+ "rand 0.9.4",
  "rayon",
  "serde",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-message",
  "solana-metrics",
- "solana-packet",
- "solana-pubkey 3.0.0",
- "solana-rayon-threadlimit",
+ "solana-packet 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
@@ -4402,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
+checksum = "778f08fb0eaf52c9a3bef2978247f7fab0ccfddc44cfddb936d5ad9f98ede886"
 dependencies = [
  "memoffset",
  "solana-account-info",
@@ -4413,13 +4164,13 @@ dependencies = [
  "solana-borsh",
  "solana-clock",
  "solana-cpi",
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-epoch-stake",
  "solana-example-mocks",
  "solana-fee-calculator",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-instructions-sysvar",
@@ -4432,8 +4183,8 @@ dependencies = [
  "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.0",
  "solana-sdk-ids",
  "solana-secp256k1-recover",
  "solana-serde-varint",
@@ -4443,7 +4194,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
- "solana-sysvar",
+ "solana-sysvar 4.0.0",
  "solana-sysvar-id",
 ]
 
@@ -4456,14 +4207,14 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-program-error"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 dependencies = [
  "borsh",
  "serde",
@@ -4481,45 +4232,49 @@ dependencies = [
 
 [[package]]
 name = "solana-program-option"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7b4ddb464f274deb4a497712664c3b612e3f5f82471d4e47710fc4ab1c3095"
+checksum = "7a88006a9b8594088cec9027ab77caaaa258a2aaa2083d3f086c44b42e50aeab"
+dependencies = [
+ "solana-nullable",
+]
 
 [[package]]
 name = "solana-program-pack"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c169359de21f6034a63ebf96d6b380980307df17a8d371344ff04a883ec4e9d0"
+checksum = "3d7701cb15b90667ae1c89ef4ac35a59c61e66ce58ddee13d729472af7f41d59"
 dependencies = [
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da9aa0062feef8162662725dbadc2f9aed390e64ab3536176085cced4b7050b"
+checksum = "dd91982ca350039915dd172226c96b046ba1124fc4ff99d63a2cb75fef3ef34e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "itertools 0.12.1",
+ "cfg-if",
+ "itertools 0.14.0",
  "log",
  "percentage",
- "rand 0.8.5",
+ "rand 0.9.4",
  "serde",
- "solana-account",
+ "solana-account 4.3.0",
  "solana-account-info",
  "solana-clock",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-structure",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-loader-v3-interface",
  "solana-program-entrypoint",
- "solana-pubkey 3.0.0",
- "solana-rent",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.0",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-slot-hashes",
@@ -4532,8 +4287,8 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-system-interface 3.2.0",
+ "solana-sysvar 4.0.0",
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
@@ -4545,35 +4300,33 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
 dependencies = [
- "rand 0.8.5",
  "solana-address 1.1.0",
 ]
 
 [[package]]
 name = "solana-pubkey"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f7104d456b58e1418c21a8581e89810278d1190f70f27ece7fc0b2c9282a57"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
- "solana-address 2.6.0",
+ "rand 0.9.4",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "solana-pubsub-client"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3b7936218ede5b8a4c87182e5ddea5185725215b2a2866246e8152e52f7fcf"
+checksum = "1d54306879778e7ff8370a018a67f46437f45d16117741676d7d73e403135fd0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
- "http 0.2.12",
  "log",
- "semver",
  "serde",
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-clock",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-rpc-client-types",
  "solana-signature",
  "thiserror 2.0.18",
@@ -4586,25 +4339,21 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4adf1b06dce39d8c0bed00eba133128b3b96c8005313245bb6863d4eefd2022"
+checksum = "3689259c44c57b0d494d030841877ef59e9c2a8315984c9a2d4105b2be5a9ced"
 dependencies = [
  "async-lock",
  "async-trait",
  "futures",
- "itertools 0.12.1",
  "log",
  "quinn",
- "quinn-proto",
- "rustls",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-pubkey 3.0.0",
- "solana-quic-definitions",
+ "solana-pubkey 4.2.0",
  "solana-rpc-client-api",
  "solana-signer",
  "solana-streamer",
@@ -4612,48 +4361,6 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.18",
  "tokio",
-]
-
-[[package]]
-name = "solana-quic-definitions"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15319accf7d3afd845817aeffa6edd8cc185f135cefbc6b985df29cfd8c09609"
-dependencies = [
- "solana-keypair",
-]
-
-[[package]]
-name = "solana-rayon-threadlimit"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c6a12644a32196de6e7dfdd5ad66183f952fe259ad4f166260838369f14a8e"
-dependencies = [
- "log",
- "num_cpus",
-]
-
-[[package]]
-name = "solana-remote-wallet"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e068304b987f1c1db02f11e1fad01e1d85bca8ecbc4f61db88a268f6927fc74"
-dependencies = [
- "console 0.16.2",
- "dialoguer",
- "log",
- "num-derive",
- "num-traits",
- "parking_lot",
- "qstring",
- "semver",
- "solana-derivation-path",
- "solana-offchain-message",
- "solana-pubkey 3.0.0",
- "solana-signature",
- "solana-signer",
- "thiserror 2.0.18",
- "uriparse",
 ]
 
 [[package]]
@@ -4670,20 +4377,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-reward-info"
-version = "3.0.0"
+name = "solana-rent"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
+checksum = "f9809b081e99bc142ce803bcd7ee18306759ce3b30a96a9da3f6f41c45e50ef0"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-reward-info"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc553b782111862cd6c56bdeba696dcba9722a42154ef1248c5a06ca1d983797"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-rpc-client"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ce2edf55df72d5334df102aee0e6798840e8911d96d9870a464337fcc86b6"
+checksum = "d9641a520e9a9349b7a011a121150ad6f9147c784a84a136ee696e0a73c86c09"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4697,7 +4418,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account",
+ "solana-account 4.3.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-clock",
@@ -4705,10 +4426,10 @@ dependencies = [
  "solana-epoch-info",
  "solana-epoch-schedule",
  "solana-feature-gate-interface",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-message",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-rpc-client-api",
  "solana-signature",
  "solana-transaction",
@@ -4721,9 +4442,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c12b2f11d22f67d0be1704c8386e4b30ea5fab2ee9bc5b92b321b533d4b81c6"
+checksum = "126830dfcf2861cfdaf73def41a857cd32fc283bdd6f0f9aecb7b70f57fd8653"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -4731,7 +4452,6 @@ dependencies = [
  "reqwest-middleware",
  "serde",
  "serde_json",
- "solana-account-decoder-client-types",
  "solana-clock",
  "solana-rpc-client-types",
  "solana-signer",
@@ -4742,16 +4462,16 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcf8cd1aad9c762370509d977072720df2aff499a2c4df9a31510d25561e626"
+checksum = "4838e4f4fc5fcaea10257901b021c2ce0f83581017ae7f40d8ea10002f6424f5"
 dependencies = [
- "solana-account",
+ "solana-account 4.3.0",
  "solana-commitment-config",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-message",
  "solana-nonce",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-rpc-client",
  "solana-sdk-ids",
  "thiserror 2.0.18",
@@ -4759,18 +4479,17 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e24a1a1bce172a4bcab315ae713fb61e364f8e8151358c7ac04d626a2794212"
+checksum = "3d7e9e4d39b1433b7228604f688bf84406d4d578864ccd2099bbdaa70a20be28"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "semver",
  "serde",
  "serde_json",
- "solana-account",
  "solana-account-decoder-client-types",
- "solana-address 1.1.0",
+ "solana-address 2.6.1",
  "solana-clock",
  "solana-commitment-config",
  "solana-fee-calculator",
@@ -4780,7 +4499,6 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",
- "spl-generic-token",
  "thiserror 2.0.18",
 ]
 
@@ -4792,16 +4510,16 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.13.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
+checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
 dependencies = [
  "byteorder",
  "combine 3.8.1",
  "hash32",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-demangle",
  "thiserror 2.0.18",
  "winapi",
@@ -4809,14 +4527,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "3.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f03df7969f5e723ad31b6c9eadccc209037ac4caa34d8dc259316b05c11e82b"
+checksum = "657e20ea41ba32cad0c493bec60b6d55cc6c30d2c1073b94cfee96dda0d764dd"
 dependencies = [
  "bincode",
  "bs58",
  "serde",
- "solana-account",
+ "solana-account 4.3.0",
  "solana-epoch-info",
  "solana-epoch-rewards-hasher",
  "solana-fee-structure",
@@ -4827,7 +4545,7 @@ dependencies = [
  "solana-presigner",
  "solana-program",
  "solana-program-memory",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-sdk-macro",
@@ -4851,40 +4569,37 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6430000e97083460b71d9fbadc52a2ab2f88f53b3a4c5e58c5ae3640a0e8c00"
+checksum = "8765316242300c48242d84a41614cb3388229ec353ba464f6fe62a733e41806f"
 dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "solana-secp256k1-recover"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de18cfdab99eeb940fbedd8c981fa130c0d76252da75d05446f22fae8b51932"
+checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
 dependencies = [
  "k256",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "solana-security-txt"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156bb61a96c605fa124e052d630dba2f6fb57e08c7d15b757e1e958b3ed7b3fe"
-dependencies = [
- "hashbrown 0.15.2",
-]
+checksum = "c94a02d486b28f219a4f8f5d7dd93cbfbb93c9f466cb7871c22e50cd5ae9a7a2"
 
 [[package]]
 name = "solana-seed-derivable"
@@ -4902,7 +4617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2",
 ]
 
@@ -4917,21 +4632,21 @@ dependencies = [
 
 [[package]]
 name = "solana-serde-varint"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5174c57d5ff3c1995f274d17156964664566e2cde18a07bba1586d35a70d3b"
+checksum = "950e5b83e839dc0f92c66afc124bb8f40e89bc90f0579e8ec5499296d27f54e3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "solana-serialize-utils"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e41dd8feea239516c623a02f0a81c2367f4b604d7965237fed0751aeec33ed"
+checksum = "761357b0853c9623bf12c1d2314b3d6160a85b087b84c45224fb85766d22616b"
 dependencies = [
  "solana-instruction-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sanitize",
 ]
 
@@ -4943,73 +4658,75 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.0.1",
+ "solana-hash 4.4.0",
 ]
 
 [[package]]
 name = "solana-short-vec"
-version = "3.1.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fb1809a32cfcf7d9c47b7070a92fa17cdb620ab5829e9a8a9ff9d138a7a175"
+checksum = "7d8250a4495aad49ad20556a607da53bdcb20de78da10b65afbf918b7f1de647"
 dependencies = [
  "serde_core",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-shred-version"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94953e22ca28fe4541a3447d6baeaf519cc4ddc063253bfa673b721f34c136bb"
+checksum = "d6c79722e299d957958bf33695f7cd1ef6724ff55563c60fd9e3e24487cccde2"
 dependencies = [
  "solana-hard-forks",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "3.1.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb8057cc0e9f7b5e89883d49de6f407df655bb6f3a71d0b7baf9986a2218fd9"
+checksum = "b0364c7577c3c82a693ce28a1febc8d1b5d1b0a175fdc2114ae6186b69effe1e"
 dependencies = [
  "ed25519-dalek",
- "five8 0.2.1",
- "rand 0.8.5",
+ "five8",
+ "rand 0.9.4",
  "serde",
  "serde-big-array",
  "serde_derive",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-signer"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
+checksum = "520bd6021163ee517f4bdc7ae03ded904f97e11320001ba0b3355f45eb14f558"
 dependencies = [
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-transaction-error",
 ]
 
 [[package]]
 name = "solana-slot-hashes"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a293f952293281443c04f4d96afd9d547721923d596e92b4377ed2360f1746"
+checksum = "0a57c158c35629f9e302ab385f16b15813f4927a31c27dda72f3df828bb08d93"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f914f6b108f5bba14a280b458d023e3621c9973f27f015a4d755b50e88d89e97"
+checksum = "0622d03a823770f7763afd866e012b296d5a3cbbbe51e110b5bd9ab3441efdca"
 dependencies = [
  "bv",
  "serde",
@@ -5020,19 +4737,19 @@ dependencies = [
 
 [[package]]
 name = "solana-stable-layout"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
+checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
 dependencies = [
  "solana-instruction",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
+checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
 dependencies = [
  "num-traits",
  "serde",
@@ -5041,28 +4758,25 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-pubkey 4.2.0",
+ "solana-system-interface 3.2.0",
+ "solana-sysvar 4.0.0",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623840c97214530c492666f473170276e9df77bf9fc62332b67f8ff4ac027e21"
+checksum = "2d429cd1395305e30b28d4e151ae8d5a1a5afeef7e76c501548058ed0197cee6"
 dependencies = [
- "arc-swap",
+ "agave-xdp",
  "bytes",
  "crossbeam-channel",
- "dashmap",
  "futures",
- "futures-util",
- "governor",
  "histogram",
  "indexmap",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "libc",
  "log",
  "nix",
@@ -5070,84 +4784,77 @@ dependencies = [
  "pem",
  "percentage",
  "quinn",
- "quinn-proto",
- "rand 0.8.5",
+ "rand 0.9.4",
  "rustls",
  "smallvec",
- "socket2",
  "solana-keypair",
- "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-packet",
+ "solana-packet 4.1.0",
  "solana-perf",
- "solana-pubkey 3.0.0",
- "solana-quic-definitions",
- "solana-signature",
+ "solana-pubkey 4.2.0",
  "solana-signer",
  "solana-time-utils",
  "solana-tls-utils",
  "solana-transaction-error",
- "solana-transaction-metrics-tracker",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "x509-parser",
 ]
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50574c1cd55286e56d5382952ceea099ee4a4426c889a3b1e456806f83bdd92"
+checksum = "096428522c522e04d189170bced59943e97f0660cafe5dc09dfbeb1f2d9d293a"
 dependencies = [
- "solana-account",
+ "solana-account 4.3.0",
  "solana-clock",
  "solana-precompile-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4a59053cd2bbee5e85476739707f5030a089457c4140340960260e7aedc2a0"
+checksum = "a039f09ec29dddcbb6797dfa6607d9d79c3d47274030bcec2da693bfb6a9e4da"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6097230b3506b5206088cb248012540f6adff10597a5da0d33c21523c79cdda"
+checksum = "964ba8077817adf4963933c930ec900c69e0e6c16cfb8e309cfe6578d9c3037e"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55976a874cc3c07e0b1ec2a1177ec420c5608f61a8735c44aef1ca7c73b829d8"
+checksum = "9df94b437896bdcf4370655ca93e39ebf1d0bd2564d73c9de0ff3162ea5b08c3"
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3434a3ba8ca342c2c9b4c89ca0b506dbf460f77f6dd1dc7cf0ba804f8d749810"
+checksum = "f3129d2c7d48e8a25d13f40af020a2525e6f43787d41c3bbef7e3ef7e78cd50e"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db058c2c629ff5dc8fb2cf234d44c0d17d8464f94c62652219de88d83fa65a52"
+checksum = "2b0f6df62bfb33980877e14264aed1ca30f61b3d659f906329c4340c81815457"
 dependencies = [
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-message",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-signature",
  "solana-transaction",
@@ -5155,11 +4862,11 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2511decc60b5c1c56d65670b42952b9a9139f0a7fa432a2a7a639c12f71f0e8"
+checksum = "cb09669f9104909d7092aca546346c061bbab9cd4302393a99d593f13faeb4b8"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -5179,43 +4886,18 @@ dependencies = [
 
 [[package]]
 name = "solana-system-interface"
-version = "3.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14591d6508042ebefb110305d3ba761615927146a26917ade45dc332d8e1ecde"
+checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
 dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
-]
-
-[[package]]
-name = "solana-system-program"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821ea87b11b2a5232e238fe8dd48f10646405f8ca5c09dd036b5b57b1b2f8116"
-dependencies = [
- "bincode",
- "log",
- "serde",
- "solana-account",
- "solana-bincode",
- "solana-fee-calculator",
- "solana-instruction",
- "solana-nonce",
- "solana-nonce-account",
- "solana-packet",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-svm-log-collector",
- "solana-svm-type-overrides",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "solana-transaction-context",
+ "wincode",
 ]
 
 [[package]]
@@ -5226,8 +4908,6 @@ checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "bytemuck",
- "bytemuck_derive",
  "lazy_static",
  "serde",
  "serde_derive",
@@ -5237,14 +4917,48 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.0.1",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey 4.0.0",
- "solana-rent",
+ "solana-pubkey 4.2.0",
+ "solana-rent 3.1.0",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1632b69b4f72489db5949a10e8308c229dfa003f99ecaa7477b376807c7b81f4"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall 5.1.0",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash 4.4.0",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.0",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
@@ -5258,7 +4972,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
  "solana-sdk-ids",
 ]
 
@@ -5270,27 +4984,24 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3173e89d55a1b85e1b86cf1384fb505a2211052e15a6f3aa4a28caf6d6b3c85"
+checksum = "38dee651967d49f172df6739a8afb6de5a2b74e07418dff5cb9e0cdc23d893d2"
 dependencies = [
  "rustls",
  "solana-keypair",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-signer",
  "x509-parser",
 ]
 
 [[package]]
 name = "solana-tpu-client"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2256899a1a9e31c70c1ea707e0b59613eec736503c7adede57accb40c50efef1"
+checksum = "5dd28e07f76f322fdafca127784e038446126b42e7d918c9849aff63972f1c2f"
 dependencies = [
- "async-trait",
- "bincode",
  "futures-util",
- "indexmap",
  "indicatif",
  "log",
  "rayon",
@@ -5299,12 +5010,9 @@ dependencies = [
  "solana-commitment-config",
  "solana-connection-cache",
  "solana-epoch-schedule",
- "solana-measure",
  "solana-message",
- "solana-net-utils",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-pubsub-client",
- "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-signature",
@@ -5313,19 +5021,19 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.18",
  "tokio",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-transaction"
-version = "3.0.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ceb2efbf427a91b884709ffac4dac29117752ce1e37e9ae04977e450aa0bb76"
+checksum = "47d105ecce084206697230226c6b2230401c220feb4dc63e1274d58b38969292"
 dependencies = [
- "bincode",
  "serde",
  "serde_derive",
- "solana-address 2.6.0",
- "solana-hash 4.0.1",
+ "solana-address 2.6.1",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
@@ -5335,30 +5043,31 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017886b71c6c22d15b08967c8d6f9e94f1745a2f01c280d08d22f82d5454bcd1"
+checksum = "b12f1cbf59ffe3ca310520f1b53fe52f0846f17ae51b29b666b031563633cfaf"
 dependencies = [
  "bincode",
  "serde",
- "solana-account",
+ "solana-account 4.3.0",
  "solana-instruction",
  "solana-instructions-sysvar",
- "solana-pubkey 3.0.0",
- "solana-rent",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.0",
  "solana-sbpf",
  "solana-sdk-ids",
 ]
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.0.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4222065402340d7e6aec9dc3e54d22992ddcf923d91edcd815443c2bfca3144a"
+checksum = "2441d6dcd51100e7d97c3fb3b723e08aa701066ff7afc00026fd8d8e222cb95b"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5367,69 +5076,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-transaction-metrics-tracker"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43917f2ad4d7faf3028a1fad990a0c5ee30e6e75913c73537eb81049ba171831"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "log",
- "rand 0.8.5",
- "solana-packet",
- "solana-perf",
- "solana-short-vec",
- "solana-signature",
-]
-
-[[package]]
-name = "solana-transaction-status"
-version = "3.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15be3ad6c8f39beffcb5e5a5c62c87696c3749e9ef20b8ec62544dec101d22a2"
-dependencies = [
- "Inflector",
- "agave-reserved-account-keys",
- "base64 0.22.1",
- "bincode",
- "borsh",
- "bs58",
- "log",
- "serde",
- "serde_json",
- "solana-account-decoder",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface",
- "solana-message",
- "solana-program-option",
- "solana-pubkey 3.0.0",
- "solana-reward-info",
- "solana-sdk-ids",
- "solana-signature",
- "solana-stake-interface",
- "solana-system-interface 2.0.0",
- "solana-transaction",
- "solana-transaction-error",
- "solana-transaction-status-client-types",
- "solana-vote-interface",
- "spl-associated-token-account-interface",
- "spl-memo-interface",
- "spl-token-2022-interface",
- "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "solana-transaction-status-client-types"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3cb8c718af0245ab3b84324f856661d87e29f193c0c0125ed0a4c212814d61"
+checksum = "1939900b1f7fae73a3acff99308509380d054ee33f7955d8a3d874f643f2891e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5440,20 +5090,20 @@ dependencies = [
  "solana-commitment-config",
  "solana-instruction",
  "solana-message",
- "solana-pubkey 3.0.0",
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf297ba743dee44f1a011b06bbdcbd7cb4a6444ae8b42148de7818b007f6078"
+checksum = "060202c42452c40ffb54b120971d55f85fc52db2933a53c9398b803915329057"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -5461,18 +5111,16 @@ dependencies = [
  "solana-net-utils",
  "solana-streamer",
  "solana-transaction-error",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]
 name = "solana-version"
-version = "3.1.6"
+version = "4.1.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1c28ae4e600f7b2b76cce76696c7ee4ab2078f5428125d04ed31c421dfb122"
+checksum = "3de9e9589e411fdb7c1f038b0678de0ac0725b21b179b7ab827efcc9eb63432e"
 dependencies = [
  "agave-feature-set",
- "rand 0.8.5",
+ "rand 0.9.4",
  "semver",
  "serde",
  "solana-sanitize",
@@ -5481,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "4.0.4"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
+checksum = "d495cb001d3373229ba523625783e5168707f70a9c38ddc90fbc5b0470d600ea"
 dependencies = [
  "bincode",
  "cfg_eval",
@@ -5493,61 +5141,40 @@ dependencies = [
  "serde_derive",
  "serde_with",
  "solana-clock",
- "solana-hash 3.1.0",
+ "solana-hash 4.4.0",
  "solana-instruction",
  "solana-instruction-error",
- "solana-pubkey 3.0.0",
- "solana-rent",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.0",
  "solana-sdk-ids",
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
-name = "solana-vote-program"
-version = "3.1.6"
+name = "solana-zero-copy"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2d2e3bfbb9c8e365f38338fa30875d2692b51057d24e776744af3d4455d06d"
+checksum = "8ea15126ebdc7e270c50d43884369af9f51d2308156d46a18e351522a164844d"
 dependencies = [
- "agave-feature-set",
- "bincode",
- "log",
- "num-derive",
- "num-traits",
- "serde",
- "solana-account",
- "solana-bincode",
- "solana-clock",
- "solana-epoch-schedule",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-keypair",
- "solana-packet",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sdk-ids",
- "solana-signer",
- "solana-slot-hashes",
- "solana-transaction",
- "solana-transaction-context",
- "solana-vote-interface",
- "thiserror 2.0.18",
+ "borsh",
+ "bytemuck",
+ "bytemuck_derive",
 ]
 
 [[package]]
 name = "solana-zk-elgamal-proof-interface"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b7f848e2b626a7bce1987e16d38c639dd9d1352676ceb09f967ca91f52639d"
+checksum = "d8da7f01db2148a1dc16261ff1dc6f3930a1e255a33cece4f1b56658694f27f7"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "num-derive",
  "num-traits",
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
  "solana-instruction",
  "solana-sdk-ids",
  "solana-zk-sdk-pod",
@@ -5571,7 +5198,7 @@ dependencies = [
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5603,12 +5230,12 @@ dependencies = [
  "curve25519-dalek",
  "itertools 0.14.0",
  "merlin",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-address 2.6.0",
+ "solana-address 2.6.1",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -5623,24 +5250,15 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk-pod"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6fbe65da9e6d1bfb747723211517d91ead9ce66cd69516f47fa44569cff151a"
+checksum = "a800583b7a4cea3e851686af162cc6e4712eef97fa91dfa9aca2459b95c84777"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
  "bytemuck_derive",
  "solana-nullable",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spinning_top"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -5669,12 +5287,12 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey 3.0.0",
- "solana-rent",
+ "solana-rent 3.1.0",
  "solana-sdk-ids",
  "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-sysvar 3.1.1",
  "spl-associated-token-account-interface",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "spl-token-interface",
  "thiserror 2.0.18",
 ]
@@ -5692,9 +5310,9 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cc11459e265d5b501534144266620289720b4c44522a47bc6b63cd295d2f3"
+checksum = "e597c5ff9ed7c74a54dbc47bae2f06e4db8c98f4356ad280200dc11878266db1"
 dependencies = [
  "bytemuck",
  "solana-program-error",
@@ -5710,7 +5328,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5722,48 +5340,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.117",
+ "syn",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "spl-elgamal-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd22edf24c47c4610b160f49c12fe33b19aec2a0968e3c9cd412fa2a94ae2bb"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "solana-zk-sdk 4.0.0",
- "spl-elgamal-registry-interface",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
 name = "spl-elgamal-registry-interface"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065f54100d118d24036283e03120b2f60cb5b7d597d3db649e13690e22d41398"
+checksum = "ee44791bc24c74bdb07cbaa419a1a34cf4d67132bba51e198bd92d332cc26b92"
 dependencies = [
  "bytemuck",
+ "solana-address 2.6.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-zk-sdk 4.0.0",
- "spl-token-confidential-transfer-proof-extraction",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
+ "spl-token-confidential-transfer-proof-extraction 0.6.1",
 ]
 
 [[package]]
@@ -5778,19 +5372,19 @@ dependencies = [
 
 [[package]]
 name = "spl-memo-interface"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4e2aedd58f858337fa609af5ad7100d4a243fdaf6a40d6eb4c28c5f19505d3"
+checksum = "3745d384b0afee980d43d62b66c27bdcbbd03507732b8d3626d3413cb72084f2"
 dependencies = [
  "solana-instruction",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "spl-pod"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1233fdecd7461611d69bb87bc2e95af742df47291975d21232a0be8217da9de"
+checksum = "2f9c6e142cdf1e7e77f480053ec9f0ce989890768ddf91f619b50f39d1b456f5"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -5801,6 +5395,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey 3.0.0",
+ "solana-zero-copy",
  "solana-zk-sdk 4.0.0",
  "thiserror 2.0.18",
 ]
@@ -5829,28 +5424,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "spl-record"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda0eb42ca6387770d7f0e764ecd8fa863f4529e9ff35fbf146576b5f4372587"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-security-txt",
- "thiserror 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -5876,43 +5450,40 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552427d9117528d037daa0e70416d51322c8a33241317210f230304d852be61e"
+checksum = "2f0e045d23300c8c9f57e52fa7a1103a20a707cc02080db929c2ff09044aa06a"
 dependencies = [
- "arrayref",
  "bytemuck",
- "num-derive",
- "num-traits",
  "num_enum",
  "solana-account-info",
+ "solana-address 2.6.1",
  "solana-clock",
  "solana-cpi",
  "solana-instruction",
  "solana-msg",
+ "solana-nullable",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent",
+ "solana-rent 3.1.0",
  "solana-sdk-ids",
  "solana-security-txt",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "solana-zk-sdk 4.0.0",
+ "solana-system-interface 3.2.0",
+ "solana-sysvar 3.1.1",
+ "solana-zero-copy",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
  "spl-elgamal-registry-interface",
  "spl-memo-interface",
- "spl-pod",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 3.0.1",
  "spl-token-confidential-transfer-ciphertext-arithmetic",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation 0.5.1",
+ "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 1.0.0",
  "spl-transfer-hook-interface",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5935,67 +5506,53 @@ dependencies = [
  "solana-sdk-ids",
  "solana-zk-sdk 4.0.0",
  "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-extraction 0.5.1",
  "spl-token-confidential-transfer-proof-generation 0.5.1",
  "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.8.0",
  "spl-type-length-value",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "spl-token-client"
-version = "0.18.0"
+name = "spl-token-2022-interface"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f87005f510593cc674a4f9f257bedbecfbb35f5aae1b66a65ef9b7dbccdeb5"
+checksum = "f5404a19d91e5604db1969f981696c199b654826e5008e9d135b844211b6799e"
 dependencies = [
- "async-trait",
- "bincode",
+ "arrayref",
  "bytemuck",
- "futures",
- "futures-util",
- "solana-account",
- "solana-cli-output",
- "solana-compute-budget-interface",
- "solana-hash 3.1.0",
+ "getrandom 0.2.17",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-address 2.6.1",
  "solana-instruction",
- "solana-message",
- "solana-packet",
+ "solana-nullable",
  "solana-program-error",
+ "solana-program-option",
  "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-signature",
- "solana-signer",
- "solana-system-interface 2.0.0",
- "solana-transaction",
- "spl-associated-token-account-interface",
- "spl-elgamal-registry",
- "spl-memo-interface",
- "spl-record",
- "spl-token-2022",
- "spl-token-2022-interface",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation 0.5.1",
+ "solana-sdk-ids",
+ "solana-zero-copy",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
+ "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
+ "spl-token-metadata-interface 1.0.0",
+ "spl-type-length-value",
  "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]
 name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbeb07f737d868f145512a4bcf9f59da275b7a3483df0add3f71eb812b689fb"
+checksum = "939382702d0a4d8060a34aa3da8ccead2d6ed22985037e2af6ad7cc8ab743f3d"
 dependencies = [
- "base64 0.22.1",
  "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk 4.0.0",
+ "solana-curve25519 4.0.1",
+ "solana-zk-sdk-pod",
 ]
 
 [[package]]
@@ -6006,7 +5563,7 @@ checksum = "879a9ebad0d77383d3ea71e7de50503554961ff0f4ef6cbca39ad126e6f6da3a"
 dependencies = [
  "bytemuck",
  "solana-account-info",
- "solana-curve25519",
+ "solana-curve25519 3.1.14",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
@@ -6015,6 +5572,26 @@ dependencies = [
  "solana-sdk-ids",
  "solana-zk-sdk 4.0.0",
  "spl-pod",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-extraction"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a845ec724e807643a04f1d43439ee3571dd913848112ac76aa90b850eaf7c"
+dependencies = [
+ "bytemuck",
+ "solana-account-info",
+ "solana-address 2.6.1",
+ "solana-curve25519 4.0.1",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-msg",
+ "solana-program-error",
+ "solana-sdk-ids",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
  "thiserror 2.0.18",
 ]
 
@@ -6044,19 +5621,20 @@ dependencies = [
 
 [[package]]
 name = "spl-token-group-interface"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452d0f758af20caaa10d9a6f7608232e000d4c74462f248540b3d2ddfa419776"
+checksum = "841cbd6f2322d02719be4da1affedbe6495b1048b7b985ec9796032564026e22"
 dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
+ "solana-address 2.6.1",
  "solana-instruction",
+ "solana-nullable",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-zero-copy",
  "spl-discriminator",
- "spl-pod",
  "thiserror 2.0.18",
 ]
 
@@ -6100,6 +5678,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-metadata-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10347d7a9b8179cb9c238f7f19419495e872ec107b4c7594eb26454ce14fe2fc"
+dependencies = [
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-address 2.6.1",
+ "solana-borsh",
+ "solana-instruction",
+ "solana-nullable",
+ "solana-program-error",
+ "spl-discriminator",
+ "spl-type-length-value",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "spl-transfer-hook-interface"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6127,19 +5725,18 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca20a1a19f4507a98ca4b28ff5ed54cac9b9d34ed27863e2bde50a3238f9a6ac"
+checksum = "2504631748c48d2a937414d64a12dcac4588d34bd07d355d648619c189d29435"
 dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
  "solana-account-info",
- "solana-msg",
  "solana-program-error",
+ "solana-zero-copy",
  "spl-discriminator",
- "spl-pod",
  "thiserror 2.0.18",
 ]
 
@@ -6148,12 +5745,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -6166,17 +5757,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -6200,53 +5780,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width 0.1.14",
+ "syn",
 ]
 
 [[package]]
@@ -6275,7 +5815,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6286,7 +5826,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6299,19 +5839,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6324,42 +5855,25 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tiny-bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
-dependencies = [
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.5",
- "rustc-hash 1.1.0",
- "sha2",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6367,9 +5881,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6382,9 +5896,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6399,13 +5913,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6462,18 +5976,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -6483,9 +5997,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -6508,19 +6022,18 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -6528,6 +6041,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6562,7 +6076,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6618,10 +6132,10 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -6632,42 +6146,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -6681,7 +6174,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6693,12 +6186,6 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6753,12 +6240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6797,18 +6278,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6819,23 +6300,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6843,31 +6320,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6885,9 +6362,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6898,14 +6375,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6943,9 +6420,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c754f1fc41250f2f742a27ba0fcc9f73df1dec23f6878490770855d43c322d"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -6956,14 +6433,14 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e070787599c7c067b89598cd3eda440cca1b69eda9e0ff7c725fc8679ce9eb4"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6987,7 +6464,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6998,7 +6475,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -7039,15 +6516,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -7258,57 +6726,47 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
- "base64 0.13.1",
  "data-encoding",
  "der-parser",
  "lazy_static",
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7317,55 +6775,55 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure 0.13.2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -7385,14 +6843,14 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7401,9 +6859,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7412,20 +6870,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,40 +8,35 @@ name = "demo-server"
 path = "src/bin/demo-server.rs"
 
 [dependencies]
-# Solana Core. zk-sdk is at 6.0.1 because the deployed devnet ZK ElGamal Proof
-# program now expects 6.0.1-format proofs. spl-token-2022 = 10.0.0 still
-# transitively pulls zk-sdk 4.0 for its own API surface, so we sidestep the
-# boundary using `ProofLocation::ContextStateAccount` (a phantom-typed Pubkey
-# that doesn't carry proof bytes) and pre-verify proofs ourselves.
-solana-sdk = "3.0.0"
-solana-client = "3.1.6"
+# Solana Core (agave v4). The whole graph is on solana-zk-sdk 6.0.1 now:
+# spl-token-2022 11.0.0 targets it natively, so there's no 4.0 ↔ 6.0.1 split
+# and no byte-casting across a version boundary.
+solana-sdk = "4.0.1"
+# Must be the 4.1 line, not 4.0.0 stable: token-2022 11 needs
+# solana-system-interface 3.2 (-> solana-instruction >=3.4), but solana-client
+# 4.0.0 caps solana-instruction <3.4. 4.1.0-beta.3 is the first published
+# client that lifts that cap. Bump to 4.1 stable once it's cut.
+solana-client = "4.1.0-beta.3"
 solana-zk-sdk = "6.0.1"
-solana-system-program = "3.1.6"
-solana-system-interface = { version = "3.0.0", features = ["bincode"] }
+solana-system-interface = { version = "3.2.0", features = ["bincode"] }
 
-# SPL Token-2022. proof-extraction stays at 0.5.1 (matches spl-token-2022's
-# transitive) so we can name the legacy `ProofLocation` type at the boundary.
-# proof-generation jumps to 0.6.0 (zk-sdk 6.0.1) for the actual proof bytes.
-spl-token-2022 = { version = "10.0.0", features = ["zk-ops"] }
-spl-token-client = "0.18.0"
+# SPL Token-2022 (agave v4 aligned). token-2022 11.0.0 builds on zk-sdk 6.0.1
+# and proof-{extraction,generation} 0.6.0 directly.
+spl-token-2022 = { version = "11.0.0", features = ["zk-ops"] }
 spl-associated-token-account = "8.0.0"
-spl-token-confidential-transfer-proof-extraction = "0.5.1"
+spl-token-confidential-transfer-proof-extraction = "0.6.0"
 spl-token-confidential-transfer-proof-generation = "0.6.0"
 
-# Bypass-mode helpers
+# ZK ElGamal proof-program helpers (create/verify/close context state accounts).
 solana-zk-elgamal-proof-interface = "0.1.2"
-solana-zk-sdk-pod = "0.1.1"
+solana-zk-sdk-pod = "0.1.2"
 solana-address = "2.6"
-bytemuck = "1.25"
-# Record program: stages the oversized range proof off-tx so the verify ix
-# fits, via encode_verify_proof_from_account.
-spl-record = { version = "0.4.0", features = ["no-entrypoint"] }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 
 # Commitment config
-solana-commitment-config = "3.1.0"
+solana-commitment-config = "3.1.1"
 
 # Demo server
 axum = "0.7"
@@ -65,4 +60,4 @@ serde_json = "1.0"
 # solana-test-validator = "=4.0.0-rc.0"
 env_logger = "0.11"
 serde_json = "1.0"
-solana-commitment-config = "3.1.0"
+solana-commitment-config = "3.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,13 @@ solana-zk-elgamal-proof-interface = "0.1.2"
 solana-zk-sdk-pod = "0.1.2"
 solana-address = "2.6"
 
+# Batched transfers (option 1): pack N transfer ixs into one v0 transaction
+# whose account list is compressed by an Address Lookup Table, plus a compute
+# budget bump so the batch clears the per-tx CU ceiling.
+solana-address-lookup-table-interface = { version = "3.1.0", features = ["bincode"] }
+solana-compute-budget-interface = "3.0.0"
+solana-message = "3.1"
+
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,24 @@ name = "demo-server"
 path = "src/bin/demo-server.rs"
 
 [dependencies]
-# Solana Core (agave v4). The whole graph is on solana-zk-sdk 6.0.1 now:
-# spl-token-2022 11.0.0 targets it natively, so there's no 4.0 ↔ 6.0.1 split
-# and no byte-casting across a version boundary.
-solana-sdk = "4.0.1"
-# Must be the 4.1 line, not 4.0.0 stable: token-2022 11 needs
-# solana-system-interface 3.2 (-> solana-instruction >=3.4), but solana-client
-# 4.0.0 caps solana-instruction <3.4. 4.1.0-beta.3 is the first published
-# client that lifts that cap. Bump to 4.1 stable once it's cut.
-solana-client = "4.1.0-beta.3"
+# Solana core via granular crates, no solana-sdk umbrella. The whole graph is
+# on solana-zk-sdk 6.0.1 (spl-token-2022 11.0.0 targets it natively, so there's
+# no 4.0 to 6.0.1 split and no byte-casting).
+#
+# solana-client is the 4.0.0-rc.0 line: its rpc-client is built on the 3.x
+# transaction/message types, so we pin solana-transaction to 3.1 to match it.
+# Everything resolves to solana-pubkey 4.2 (= solana_address::Address), so
+# Pubkey == Address and no conversions are needed. Using the umbrella solana-sdk
+# 4.x instead would drag in transaction 4.x (mismatch with the rc rpc-client)
+# and the wincode skew, hence the granular crates.
+solana-client = "4.0.0-rc.0"
+solana-pubkey = "4.2"
+solana-keypair = "3.1"
+solana-signer = "3.0"
+solana-signature = "3.0"
+solana-transaction = "3.1"
+solana-instruction = "3.4"
+solana-native-token = "3.0"
 solana-zk-sdk = "6.0.1"
 solana-system-interface = { version = "3.2.0", features = ["bincode"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,12 @@ solana-zk-elgamal-proof-interface = "0.1.2"
 solana-zk-sdk-pod = "0.1.2"
 solana-address = "2.6"
 
+# Transfer-with-fee: the U256 range proof verify ix exceeds the 1232-byte tx
+# limit, so its bytes are staged into an spl-record account (bytemuck to view
+# the proof data as bytes) and verified from there.
+spl-record = { version = "0.4.0", features = ["no-entrypoint"] }
+bytemuck = "1.25"
+
 # Batched transfers (option 1): pack N transfer ixs into one v0 transaction
 # whose account list is compressed by an Address Lookup Table, plus a compute
 # budget bump so the batch clears the per-tx CU ceiling.

--- a/README.md
+++ b/README.md
@@ -82,52 +82,46 @@ Confidential transfers require zero-knowledge proofs verified by a dedicated Sol
 ### Rust Crates
 
 ```toml
-# Solana core. zk-sdk is at 6.0.1 because the deployed devnet ZK ElGamal Proof
-# program now expects 6.0.1-format proofs.
-solana-sdk = "3.0.0"
-solana-client = "3.1.6"
+# Solana core (agave v4). The whole graph is on solana-zk-sdk 6.0.1:
+# spl-token-2022 11.0.0 targets it natively, so there is no version boundary
+# to cross and no byte-casting.
+solana-sdk = "4.0.1"
+solana-client = "4.1.0-beta.3"
 solana-zk-sdk = "6.0.1"
+solana-system-interface = "3.2.0"
 
-# SPL Token-2022. proof-extraction stays at 0.5.1 (matches spl-token-2022's
-# transitive zk-sdk 4.0) so we can name the legacy `ProofLocation` type at the
-# instruction boundary. proof-generation is on 0.6.0 (zk-sdk 6.0.1) for the
-# actual proof bytes.
-spl-token-2022 = "10.0.0"
-spl-token-client = "0.18.0"
+# SPL Token-2022 (agave v4 aligned), all on zk-sdk 6.0.1.
+spl-token-2022 = "11.0.0"
 spl-associated-token-account = "8.0.0"
 spl-token-confidential-transfer-proof-generation = "0.6.0"
-spl-token-confidential-transfer-proof-extraction = "0.5.1"
+spl-token-confidential-transfer-proof-extraction = "0.6.0"
 
-# Bypass-mode helpers (see "Bypass mode" below)
+# ZK ElGamal proof-program helpers (create/verify/close context state accounts).
 solana-zk-elgamal-proof-interface = "0.1.2"
-solana-zk-sdk-pod = "0.1.1"
+solana-zk-sdk-pod = "0.1.2"
 solana-address = "2.6"
-bytemuck = "1.25"
 ```
 
-### Bypass mode (the 4.0 ↔ 6.0.1 boundary)
+> **Version note: `solana-client` is pinned to `4.1.0-beta.3` on purpose.**
+> `spl-token-2022 = 11.0.0` requires `solana-system-interface 3.2`, which in
+> turn needs `solana-instruction >= 3.4`. The only stable client, `solana-client
+> 4.0.0`, caps `solana-instruction < 3.4`, so it cannot coexist with token-2022
+> 11. `4.1.0-beta.3` is the first published client that lifts that cap, so a beta
+> is required for now. Bump this to a stable `solana-client` 4.1 once it ships
+> (that is the only change needed to go fully stable).
 
-This split is a **stopgap, not a design choice**. `spl-token-client` and
-`spl-token-2022` should be on the agave v4 beta / rc crates (which target
-`solana-zk-sdk = 6.0.1` natively), but those Agave v4 crates haven't been
-published yet. Until they are, `spl-token-2022 = 10.0.0` transitively pulls
-`solana-zk-sdk = 4.0` for its public API while the deployed ZK ElGamal Proof
-program on devnet verifies 6.0.1-format proofs. This repo bridges the gap:
+Confidential transfers run entirely on `solana-zk-sdk 6.0.1`: keys and proofs
+are generated with 6.0.1, pre-verified into `ProofContextState` accounts, and
+referenced from spl-token-2022's instruction builders via
+`ProofLocation::ContextStateAccount`. token-2022 11's account fields and
+builders speak the `solana-zk-sdk-pod` POD types directly, so no version
+bridging is needed.
 
-1. Derive ElGamal + AES keys with `solana-zk-sdk = 6.0.1` directly.
-2. Generate proofs with `proof-generation = 0.6.0`.
-3. Pre-verify each proof into a `ProofContextState` account.
-4. Reference those accounts in spl-token-2022's instruction builders via
-   `ProofLocation::ContextStateAccount` — a phantom-typed `Pubkey` that
-   carries no proof bytes, so the version mismatch never crosses the FFI.
-5. Cross the type boundary only at on-chain PODs (ElGamal pubkey/ciphertext,
-   AES ciphertext) using zero-copy byte casts, since their wire format is
-   identical between 4.0 and 6.0.1.
-
-Every module in `src/` follows this pattern; `*Legacy` aliases mark the
-4.0 side of the boundary. Once the v4 crates are published, the bypass and
-the `*Legacy` aliases can be deleted and everything routes through 6.0.1
-directly.
+(A residual `solana-zk-sdk 4.0` still appears in `Cargo.lock` as transitive
+baggage from `spl-pod` and the older `spl-token-2022-interface 2.1.0` pulled by
+`spl-associated-token-account` / `solana-account-decoder`. It is off the
+confidential-transfer path and harmless; it clears once those crates move to
+`spl-token-2022-interface 3.0.0` / zk-sdk 6.0.1 upstream.)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,17 @@ Confidential transfers require zero-knowledge proofs verified by a dedicated Sol
 ### Rust Crates
 
 ```toml
-# Solana core (agave v4). The whole graph is on solana-zk-sdk 6.0.1:
-# spl-token-2022 11.0.0 targets it natively, so there is no version boundary
-# to cross and no byte-casting.
-solana-sdk = "4.0.1"
-solana-client = "4.1.0-beta.3"
+# Solana core via granular crates (no solana-sdk umbrella). The whole graph is
+# on solana-zk-sdk 6.0.1: spl-token-2022 11.0.0 targets it natively, so there is
+# no version boundary to cross and no byte-casting.
+solana-client = "4.0.0-rc.0"
+solana-pubkey = "4.2"        # = solana_address::Address (provides the pubkey! macro)
+solana-keypair = "3.1"
+solana-signer = "3.0"
+solana-signature = "3.0"
+solana-transaction = "3.1"   # matches the rc rpc-client (3.x transaction types)
+solana-instruction = "3.4"
+solana-native-token = "3.0"
 solana-zk-sdk = "6.0.1"
 solana-system-interface = "3.2.0"
 
@@ -102,13 +108,18 @@ solana-zk-sdk-pod = "0.1.2"
 solana-address = "2.6"
 ```
 
-> **Version note: `solana-client` is pinned to `4.1.0-beta.3` on purpose.**
-> `spl-token-2022 = 11.0.0` requires `solana-system-interface 3.2`, which in
-> turn needs `solana-instruction >= 3.4`. The only stable client, `solana-client
-> 4.0.0`, caps `solana-instruction < 3.4`, so it cannot coexist with token-2022
-> 11. `4.1.0-beta.3` is the first published client that lifts that cap, so a beta
-> is required for now. Bump this to a stable `solana-client` 4.1 once it ships
-> (that is the only change needed to go fully stable).
+> **Version note: this uses granular Solana crates on the `4.0.0-rc.0` line, not
+> the `solana-sdk` umbrella.** `spl-token-2022 = 11.0.0` requires
+> `solana-system-interface 3.2`, which needs `solana-instruction >= 3.4`. The only
+> stable `solana-client` (4.0.0) caps `solana-instruction < 3.4`, so it can't
+> coexist with token-2022 11. The `4.0.0-rc.0` client lifts that cap, but its
+> rpc-client is built on the 3.x `solana-transaction`/`solana-message` types, so
+> we pin `solana-transaction = "3.1"` and pull the rest as granular crates rather
+> than the `solana-sdk` 4.x umbrella (which would force `transaction 4.x` and a
+> `wincode` version skew). Everything resolves to `solana-pubkey 4.2`, which is
+> `Address as Pubkey`, so `Pubkey == Address` and no conversions are needed.
+> These rc/3.x pins can collapse back to a plain `solana-sdk` once a stable
+> `solana-client` ships that allows `solana-instruction 3.4`.
 
 Confidential transfers run entirely on `solana-zk-sdk 6.0.1`: keys and proofs
 are generated with 6.0.1, pre-verified into `ProofContextState` accounts, and

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ cargo run --example batch_transfer_atomic
 SOLANA_RPC_URL=https://zk-edge.surfnet.dev:8899 \
 PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) \
 cargo run --example batch_transfer_pipelined
+
+# Confidential transfer on a mint with transfer fees + permanent delegate
+SOLANA_RPC_URL=https://api.devnet.solana.com \
+PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) \
+cargo run --example run_transfer_with_fees
 ```
 
 **Available Operations:**
@@ -184,6 +189,7 @@ cargo run --example batch_transfer_pipelined
 - `src/apply_pending.rs` - Apply pending balance to available balance
 - `src/withdraw.rs` - Withdraw from confidential to public balance
 - `src/transfer.rs` - Transfer confidentially between accounts (with proof context state accounts)
+- `src/transfer_with_fee.rs` - Transfer on a mint with confidential transfer fees (5 proofs, record-staged U256 range proof)
 - `src/batch_transfer.rs` - Batch multiple transfers from one sender (atomic v0+ALT, or pipelined)
 
 **Examples:**
@@ -191,6 +197,7 @@ cargo run --example batch_transfer_pipelined
 - `examples/get_balances.rs` - Query and decrypt all balance types (public, pending, available)
 - `examples/batch_transfer_atomic.rs` - N transfers from one sender in a single atomic transaction
 - `examples/batch_transfer_pipelined.rs` - N transfers from one sender, one confirmed tx per leg
+- `examples/run_transfer_with_fees.rs` - Fee-enabled mint: confidential transfer with fee, fee decryption + harvest, permanent-delegate burn
 
 **Batching from one sender.** Spending is a read-modify-write against the sender's opaque
 available-balance ciphertext, so transfers from one account are inherently ordered: each leg's
@@ -202,6 +209,16 @@ into context state accounts and lands every `Transfer` in one v0 transaction (an
 Table compresses the account list, a compute-budget bump clears the CU ceiling); in-order execution
 makes the chained proofs validate deterministically. `batch_transfer_pipelined` submits one confirmed
 transaction per leg instead, trading latency for unbounded fan-out past the single-tx size/CU limit.
+
+**Transfers with fees.** A mint carrying `TransferFeeConfig` + `ConfidentialTransferFeeConfig`
+withholds a fee on every confidential transfer, encrypted on the recipient account under the
+mint's withdraw-withheld authority ElGamal key. The fee-aware transfer needs five proofs instead
+of three (equality, transfer-amount validity, percentage-with-cap, fee validity, and a U256 range
+proof). The U256 range proof's verify instruction alone exceeds the 1232-byte transaction limit,
+so `transfer_with_fee.rs` stages its bytes into an spl-record account across multiple writes and
+verifies from there. `run_transfer_with_fees` demonstrates the full loop — transfer, decrypting
+the withheld fee, harvesting it to the mint — plus a `PermanentDelegate` burning from the
+recipient's account without their signature.
 
 All operations are tested in `tests/integration_test.rs` with complete end-to-end flows.
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ SOLANA_RPC_URL=https://zk-edge.surfnet.dev:8899 \
 MINT_ADDRESS=<mint> \
 OWNER_KEYPAIR=$(cat ~/.config/solana/id.json) \
 cargo run --example get_balances
+
+# Batched transfers from one sender, all legs in a single atomic v0 tx (option 1)
+SOLANA_RPC_URL=https://zk-edge.surfnet.dev:8899 \
+PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) \
+cargo run --example batch_transfer_atomic
+
+# Batched transfers from one sender, one confirmed tx per leg (option 2)
+SOLANA_RPC_URL=https://zk-edge.surfnet.dev:8899 \
+PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) \
+cargo run --example batch_transfer_pipelined
 ```
 
 **Available Operations:**
@@ -174,10 +184,24 @@ cargo run --example get_balances
 - `src/apply_pending.rs` - Apply pending balance to available balance
 - `src/withdraw.rs` - Withdraw from confidential to public balance
 - `src/transfer.rs` - Transfer confidentially between accounts (with proof context state accounts)
+- `src/batch_transfer.rs` - Batch multiple transfers from one sender (atomic v0+ALT, or pipelined)
 
 **Examples:**
 - `examples/run_transfer.rs` - Complete end-to-end transfer with balance display at each step
 - `examples/get_balances.rs` - Query and decrypt all balance types (public, pending, available)
+- `examples/batch_transfer_atomic.rs` - N transfers from one sender in a single atomic transaction
+- `examples/batch_transfer_pipelined.rs` - N transfers from one sender, one confirmed tx per leg
+
+**Batching from one sender.** Spending is a read-modify-write against the sender's opaque
+available-balance ciphertext, so transfers from one account are inherently ordered: each leg's
+equality proof binds to the ciphertext the previous leg leaves behind. `batch_transfer` exploits
+the fact that the sender holds the secret to compute the whole chain of intermediate ciphertexts
+*offline* (ElGamal subtracts homomorphically; each proof exposes the next available-balance
+ciphertext), generating every proof up front. `batch_transfer_atomic` then pre-verifies all proofs
+into context state accounts and lands every `Transfer` in one v0 transaction (an Address Lookup
+Table compresses the account list, a compute-budget bump clears the CU ceiling); in-order execution
+makes the chained proofs validate deterministically. `batch_transfer_pipelined` submits one confirmed
+transaction per leg instead, trading latency for unbounded fan-out past the single-tx size/CU limit.
 
 All operations are tested in `tests/integration_test.rs` with complete end-to-end flows.
 

--- a/examples/batch_transfer_atomic.rs
+++ b/examples/batch_transfer_atomic.rs
@@ -1,0 +1,62 @@
+//! Example (option 1): batched confidential transfers from one sender, executed
+//! atomically in a single v0 transaction.
+//!
+//! Every leg's proofs are pre-verified into context state accounts, an Address
+//! Lookup Table compresses the account list, and one v0 transaction carries a
+//! compute-budget bump plus all N `Transfer` instructions. In-order execution
+//! within the transaction lets the offline-chained proofs validate against the
+//! exact intermediate ciphertext each leg expects: all legs land, or none do.
+//!
+//! Bounded by transaction size and compute units. For very large fan-out, use
+//! the pipelined example instead.
+//!
+//! Usage:
+//! SOLANA_RPC_URL=https://api.devnet.solana.com \
+//! PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) \
+//! cargo run --example batch_transfer_atomic
+
+mod common;
+
+use conf_balances_examples::batch_transfer::{batch_transfer_atomic, TransferLeg};
+use solana_sdk::signature::Signer;
+
+/// CU ceiling for the atomic transaction. Each pre-verified `Transfer` does
+/// ciphertext arithmetic (not full proof verification), so this leaves headroom
+/// for a few legs; raise or lower with the batch size.
+const COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Three legs comfortably exceed a legacy transaction's 1232-byte limit once
+    // every proof context account is referenced, which is exactly why this path
+    // uses an Address Lookup Table + v0 transaction.
+    let amounts: [u64; 3] = [120_000_000, 60_000_000, 30_000_000];
+    let scenario = common::setup(amounts.len(), 1_000_000_000).await?;
+
+    let legs: Vec<TransferLeg> = scenario
+        .recipients
+        .iter()
+        .zip(amounts)
+        .map(|(r, amount)| TransferLeg {
+            recipient: r.pubkey(),
+            amount,
+        })
+        .collect();
+
+    println!("\n🔐 Atomic batch transfer ({} legs in one tx)...", legs.len());
+    let sigs = batch_transfer_atomic(
+        &scenario.client,
+        &scenario.payer,
+        &scenario.sender,
+        &scenario.mint,
+        &legs,
+        COMPUTE_UNIT_LIMIT,
+    )
+    .await?;
+
+    println!("\n📊 Final balances:");
+    common::print_available(&scenario.client, "sender", &scenario.sender, &scenario.mint)?;
+
+    println!("\n📝 {} transactions total (staging + 1 atomic transfer + cleanup)", sigs.len());
+    Ok(())
+}

--- a/examples/batch_transfer_atomic.rs
+++ b/examples/batch_transfer_atomic.rs
@@ -18,7 +18,7 @@
 mod common;
 
 use conf_balances_examples::batch_transfer::{batch_transfer_atomic, TransferLeg};
-use solana_sdk::signature::Signer;
+use solana_signer::Signer;
 
 /// CU ceiling for the atomic transaction. Each pre-verified `Transfer` does
 /// ciphertext arithmetic (not full proof verification), so this leaves headroom

--- a/examples/batch_transfer_pipelined.rs
+++ b/examples/batch_transfer_pipelined.rs
@@ -1,0 +1,50 @@
+//! Example (option 2): batched confidential transfers from one sender, shipped
+//! as a pipeline of confirmed transactions.
+//!
+//! All proofs are generated offline up front against the chained sender state,
+//! then each leg is staged, transferred, and closed in order. No transaction
+//! size or compute ceiling, so the fan-out is unbounded; the cost is one round
+//! of confirmation per leg.
+//!
+//! Usage:
+//! SOLANA_RPC_URL=https://api.devnet.solana.com \
+//! PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) \
+//! cargo run --example batch_transfer_pipelined
+
+mod common;
+
+use conf_balances_examples::batch_transfer::{batch_transfer_pipelined, TransferLeg};
+use solana_sdk::signature::Signer;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Fund with 1 token (1e9 base units); send 4 legs of varying size.
+    let amounts: [u64; 4] = [100_000_000, 50_000_000, 25_000_000, 10_000_000];
+    let scenario = common::setup(amounts.len(), 1_000_000_000).await?;
+
+    let legs: Vec<TransferLeg> = scenario
+        .recipients
+        .iter()
+        .zip(amounts)
+        .map(|(r, amount)| TransferLeg {
+            recipient: r.pubkey(),
+            amount,
+        })
+        .collect();
+
+    println!("\n🔐 Pipelined batch transfer ({} legs)...", legs.len());
+    let sigs = batch_transfer_pipelined(
+        &scenario.client,
+        &scenario.payer,
+        &scenario.sender,
+        &scenario.mint,
+        &legs,
+    )
+    .await?;
+
+    println!("\n📊 Final balances:");
+    common::print_available(&scenario.client, "sender", &scenario.sender, &scenario.mint)?;
+
+    println!("\n📝 {} transactions total", sigs.len());
+    Ok(())
+}

--- a/examples/batch_transfer_pipelined.rs
+++ b/examples/batch_transfer_pipelined.rs
@@ -14,7 +14,7 @@
 mod common;
 
 use conf_balances_examples::batch_transfer::{batch_transfer_pipelined, TransferLeg};
-use solana_sdk::signature::Signer;
+use solana_signer::Signer;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,32 +1,20 @@
 //! Shared scaffolding for the batch-transfer examples: spin up a confidential
 //! mint, fund a sender's confidential available balance, and configure a set of
-//! recipient accounts ready to receive. Both `batch_transfer_atomic` and
-//! `batch_transfer_pipelined` examples build on this.
+//! recipient accounts ready to receive. The heavy lifting lives in the library
+//! (`setup`, `balances`, `deposit`, `apply_pending`); this just orchestrates it.
 
-use conf_balances_examples::*;
+use conf_balances_examples::balances::read_balances;
+use conf_balances_examples::setup::{
+    create_and_configure_account, create_confidential_mint, load_keypair_env,
+};
+use conf_balances_examples::{apply_pending, deposit};
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_sdk::{
-    native_token::LAMPORTS_PER_SOL,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use solana_zk_sdk::encryption::{
-    auth_encryption::{AeCiphertext, AeKey},
-    elgamal::{ElGamalCiphertext, ElGamalKeypair},
-};
-use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{
-    extension::{
-        confidential_transfer::ConfidentialTransferAccount, BaseStateWithExtensions,
-        StateWithExtensions,
-    },
-    state::Account as TokenAccount,
-};
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use std::env;
 use std::error::Error;
 
@@ -42,137 +30,15 @@ pub struct Scenario {
     pub recipients: Vec<Keypair>,
 }
 
-/// Load the payer keypair from `PAYER_KEYPAIR` (a JSON byte array).
-fn load_payer() -> Result<Keypair, Box<dyn Error>> {
-    let keypair_json = env::var("PAYER_KEYPAIR")
-        .map_err(|_| "PAYER_KEYPAIR environment variable not set")?;
-    let bytes: Vec<u8> = serde_json::from_str(&keypair_json)?;
-    if bytes.len() != 64 {
-        return Err(format!("Invalid keypair: expected 64 bytes, got {}", bytes.len()).into());
-    }
-    let mut secret_key = [0u8; 32];
-    secret_key.copy_from_slice(&bytes[0..32]);
-    Ok(Keypair::new_from_array(secret_key))
-}
-
-/// Create a confidential-transfer mint (auto-approve, random auditor key).
-fn create_confidential_mint(client: &RpcClient, payer: &Keypair) -> Result<Keypair, Box<dyn Error>> {
-    use solana_system_interface::instruction as system_instruction;
-    use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey as PodElGamalPubkeyV6;
-    use spl_token_2022::{
-        extension::{confidential_transfer::instruction::initialize_mint, ExtensionType},
-        instruction::initialize_mint as initialize_mint_base,
-        solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey as PodElGamalPubkeyLegacy,
-        state::Mint,
-    };
-
-    let mint = Keypair::new();
-    let space = ExtensionType::try_calculate_account_len::<Mint>(&[
-        ExtensionType::ConfidentialTransferMint,
-    ])?;
-    let rent = client.get_minimum_balance_for_rent_exemption(space)?;
-
-    let auditor_elgamal = ElGamalKeypair::new_rand();
-    let auditor_pod_v6: PodElGamalPubkeyV6 = (*auditor_elgamal.pubkey()).into();
-    let auditor_pubkey_pod = PodElGamalPubkeyLegacy::from(auditor_pod_v6.0);
-
-    let create_account_ix = system_instruction::create_account(
-        &payer.pubkey(),
-        &mint.pubkey(),
-        rent,
-        space as u64,
-        &spl_token_2022::id(),
-    );
-    let init_ct_ix = initialize_mint(
-        &spl_token_2022::id(),
-        &mint.pubkey(),
-        None,
-        true,
-        Some(auditor_pubkey_pod),
-    )?;
-    let init_mint_ix = initialize_mint_base(
-        &spl_token_2022::id(),
-        &mint.pubkey(),
-        &payer.pubkey(),
-        None,
-        DECIMALS,
-    )?;
-
-    let blockhash = client.get_latest_blockhash()?;
-    let tx = Transaction::new_signed_with_payer(
-        &[create_account_ix, init_ct_ix, init_mint_ix],
-        Some(&payer.pubkey()),
-        &[payer, &mint],
-        blockhash,
-    );
-    client.send_and_confirm_transaction(&tx)?;
-    Ok(mint)
-}
-
-/// Create a Token-2022 ATA for `owner` and configure it for confidential transfers.
-async fn create_and_configure(
-    client: &RpcClient,
-    payer: &Keypair,
-    owner: &Keypair,
-    mint: &Pubkey,
-) -> Result<(), Box<dyn Error>> {
-    let create_ata_ix = create_associated_token_account(
-        &payer.pubkey(),
-        &owner.pubkey(),
-        mint,
-        &spl_token_2022::id(),
-    );
-    let blockhash = client.get_latest_blockhash()?;
-    let tx = Transaction::new_signed_with_payer(
-        &[create_ata_ix],
-        Some(&payer.pubkey()),
-        &[payer],
-        blockhash,
-    );
-    client.send_and_confirm_transaction(&tx)?;
-
-    configure::configure_account_for_confidential_transfers(client, payer, owner, mint).await?;
-    Ok(())
-}
-
-/// Decrypt and pretty-print an account's confidential available balance.
+/// Decrypt and print an account's confidential available balance.
 pub fn print_available(
     client: &RpcClient,
     label: &str,
     owner: &Keypair,
     mint: &Pubkey,
 ) -> Result<(), Box<dyn Error>> {
-    let token_account =
-        get_associated_token_address_with_program_id(&owner.pubkey(), mint, &spl_token_2022::id());
-    let elgamal_keypair = ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes())?;
-    let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes())?;
-
-    let account_data = client.get_account(&token_account)?;
-    let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
-    let ext = account.get_extension::<ConfidentialTransferAccount>()?;
-
-    let available_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ext.available_balance)
-            .try_into()
-            .map_err(|_| "available_balance size")?,
-    );
-    let available_ct: ElGamalCiphertext = available_v6
-        .try_into()
-        .map_err(|e| format!("decode available_balance: {e:?}"))?;
-    let available = available_ct
-        .decrypt_u32(elgamal_keypair.secret())
-        .unwrap_or(0);
-
-    let avail_aes_bytes: [u8; 36] = bytemuck::bytes_of(&ext.decryptable_available_balance)
-        .try_into()
-        .map_err(|_| "decryptable size")?;
-    let decryptable = AeCiphertext::from_bytes(&avail_aes_bytes)
-        .and_then(|c| aes_key.decrypt(&c))
-        .unwrap_or(0);
-
-    println!(
-        "   {label}: available(ElGamal)={available}, decryptable(AES)={decryptable}"
-    );
+    let b = read_balances(client, owner, mint)?;
+    println!("   {label}: available={}, pending={}, public={}", b.available, b.pending, b.public);
     Ok(())
 }
 
@@ -184,7 +50,7 @@ pub async fn setup(num_recipients: usize, funding: u64) -> Result<Scenario, Box<
     println!("🔗 Connecting to: {rpc_url}");
     let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
 
-    let payer = load_payer()?;
+    let payer = load_keypair_env("PAYER_KEYPAIR")?;
     let sender = Keypair::new();
     println!("💰 Payer:  {}", payer.pubkey());
     println!(
@@ -194,13 +60,13 @@ pub async fn setup(num_recipients: usize, funding: u64) -> Result<Scenario, Box<
     println!("📤 Sender: {}", sender.pubkey());
 
     println!("\n🏭 Creating confidential mint...");
-    let mint = create_confidential_mint(&client, &payer)?;
+    let mint = create_confidential_mint(&client, &payer, DECIMALS)?;
     println!("   Mint: {}", mint.pubkey());
 
     println!("\n🎫 Configuring sender...");
-    create_and_configure(&client, &payer, &sender, &mint.pubkey()).await?;
+    create_and_configure_account(&client, &payer, &sender, &mint.pubkey()).await?;
 
-    let sender_token_account = get_associated_token_address_with_program_id(
+    let sender_token_account = spl_associated_token_account::get_associated_token_address_with_program_id(
         &sender.pubkey(),
         &mint.pubkey(),
         &spl_token_2022::id(),
@@ -234,7 +100,7 @@ pub async fn setup(num_recipients: usize, funding: u64) -> Result<Scenario, Box<
     let mut recipients = Vec::with_capacity(num_recipients);
     for i in 0..num_recipients {
         let recipient = Keypair::new();
-        create_and_configure(&client, &payer, &recipient, &mint.pubkey()).await?;
+        create_and_configure_account(&client, &payer, &recipient, &mint.pubkey()).await?;
         println!("   recipient {}: {}", i + 1, recipient.pubkey());
         recipients.push(recipient);
     }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,249 @@
+//! Shared scaffolding for the batch-transfer examples: spin up a confidential
+//! mint, fund a sender's confidential available balance, and configure a set of
+//! recipient accounts ready to receive. Both `batch_transfer_atomic` and
+//! `batch_transfer_pipelined` examples build on this.
+
+use conf_balances_examples::*;
+use solana_client::rpc_client::RpcClient;
+use solana_commitment_config::CommitmentConfig;
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use solana_zk_sdk::encryption::{
+    auth_encryption::{AeCiphertext, AeKey},
+    elgamal::{ElGamalCiphertext, ElGamalKeypair},
+};
+use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
+use spl_associated_token_account::{
+    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
+};
+use spl_token_2022::{
+    extension::{
+        confidential_transfer::ConfidentialTransferAccount, BaseStateWithExtensions,
+        StateWithExtensions,
+    },
+    state::Account as TokenAccount,
+};
+use std::env;
+use std::error::Error;
+
+pub const DECIMALS: u8 = 9;
+
+/// Everything an example needs after setup: a funded confidential sender and a
+/// list of configured recipients.
+pub struct Scenario {
+    pub client: RpcClient,
+    pub payer: Keypair,
+    pub sender: Keypair,
+    pub mint: Pubkey,
+    pub recipients: Vec<Keypair>,
+}
+
+/// Load the payer keypair from `PAYER_KEYPAIR` (a JSON byte array).
+fn load_payer() -> Result<Keypair, Box<dyn Error>> {
+    let keypair_json = env::var("PAYER_KEYPAIR")
+        .map_err(|_| "PAYER_KEYPAIR environment variable not set")?;
+    let bytes: Vec<u8> = serde_json::from_str(&keypair_json)?;
+    if bytes.len() != 64 {
+        return Err(format!("Invalid keypair: expected 64 bytes, got {}", bytes.len()).into());
+    }
+    let mut secret_key = [0u8; 32];
+    secret_key.copy_from_slice(&bytes[0..32]);
+    Ok(Keypair::new_from_array(secret_key))
+}
+
+/// Create a confidential-transfer mint (auto-approve, random auditor key).
+fn create_confidential_mint(client: &RpcClient, payer: &Keypair) -> Result<Keypair, Box<dyn Error>> {
+    use solana_system_interface::instruction as system_instruction;
+    use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey as PodElGamalPubkeyV6;
+    use spl_token_2022::{
+        extension::{confidential_transfer::instruction::initialize_mint, ExtensionType},
+        instruction::initialize_mint as initialize_mint_base,
+        solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey as PodElGamalPubkeyLegacy,
+        state::Mint,
+    };
+
+    let mint = Keypair::new();
+    let space = ExtensionType::try_calculate_account_len::<Mint>(&[
+        ExtensionType::ConfidentialTransferMint,
+    ])?;
+    let rent = client.get_minimum_balance_for_rent_exemption(space)?;
+
+    let auditor_elgamal = ElGamalKeypair::new_rand();
+    let auditor_pod_v6: PodElGamalPubkeyV6 = (*auditor_elgamal.pubkey()).into();
+    let auditor_pubkey_pod = PodElGamalPubkeyLegacy::from(auditor_pod_v6.0);
+
+    let create_account_ix = system_instruction::create_account(
+        &payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &spl_token_2022::id(),
+    );
+    let init_ct_ix = initialize_mint(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        None,
+        true,
+        Some(auditor_pubkey_pod),
+    )?;
+    let init_mint_ix = initialize_mint_base(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        &payer.pubkey(),
+        None,
+        DECIMALS,
+    )?;
+
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[create_account_ix, init_ct_ix, init_mint_ix],
+        Some(&payer.pubkey()),
+        &[payer, &mint],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+    Ok(mint)
+}
+
+/// Create a Token-2022 ATA for `owner` and configure it for confidential transfers.
+async fn create_and_configure(
+    client: &RpcClient,
+    payer: &Keypair,
+    owner: &Keypair,
+    mint: &Pubkey,
+) -> Result<(), Box<dyn Error>> {
+    let create_ata_ix = create_associated_token_account(
+        &payer.pubkey(),
+        &owner.pubkey(),
+        mint,
+        &spl_token_2022::id(),
+    );
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ata_ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+
+    configure::configure_account_for_confidential_transfers(client, payer, owner, mint).await?;
+    Ok(())
+}
+
+/// Decrypt and pretty-print an account's confidential available balance.
+pub fn print_available(
+    client: &RpcClient,
+    label: &str,
+    owner: &Keypair,
+    mint: &Pubkey,
+) -> Result<(), Box<dyn Error>> {
+    let token_account =
+        get_associated_token_address_with_program_id(&owner.pubkey(), mint, &spl_token_2022::id());
+    let elgamal_keypair = ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes())?;
+    let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes())?;
+
+    let account_data = client.get_account(&token_account)?;
+    let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
+    let ext = account.get_extension::<ConfidentialTransferAccount>()?;
+
+    let available_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
+        bytemuck::bytes_of(&ext.available_balance)
+            .try_into()
+            .map_err(|_| "available_balance size")?,
+    );
+    let available_ct: ElGamalCiphertext = available_v6
+        .try_into()
+        .map_err(|e| format!("decode available_balance: {e:?}"))?;
+    let available = available_ct
+        .decrypt_u32(elgamal_keypair.secret())
+        .unwrap_or(0);
+
+    let avail_aes_bytes: [u8; 36] = bytemuck::bytes_of(&ext.decryptable_available_balance)
+        .try_into()
+        .map_err(|_| "decryptable size")?;
+    let decryptable = AeCiphertext::from_bytes(&avail_aes_bytes)
+        .and_then(|c| aes_key.decrypt(&c))
+        .unwrap_or(0);
+
+    println!(
+        "   {label}: available(ElGamal)={available}, decryptable(AES)={decryptable}"
+    );
+    Ok(())
+}
+
+/// Stand up a mint, fund the sender's confidential available balance with
+/// `funding` base units, and create `num_recipients` configured recipients.
+pub async fn setup(num_recipients: usize, funding: u64) -> Result<Scenario, Box<dyn Error>> {
+    let rpc_url =
+        env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
+    println!("🔗 Connecting to: {rpc_url}");
+    let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+    let payer = load_payer()?;
+    let sender = Keypair::new();
+    println!("💰 Payer:  {}", payer.pubkey());
+    println!(
+        "💳 Balance: {} SOL",
+        client.get_balance(&payer.pubkey())? as f64 / LAMPORTS_PER_SOL as f64
+    );
+    println!("📤 Sender: {}", sender.pubkey());
+
+    println!("\n🏭 Creating confidential mint...");
+    let mint = create_confidential_mint(&client, &payer)?;
+    println!("   Mint: {}", mint.pubkey());
+
+    println!("\n🎫 Configuring sender...");
+    create_and_configure(&client, &payer, &sender, &mint.pubkey()).await?;
+
+    let sender_token_account = get_associated_token_address_with_program_id(
+        &sender.pubkey(),
+        &mint.pubkey(),
+        &spl_token_2022::id(),
+    );
+
+    println!("🪙 Minting {funding} base units to sender...");
+    let mint_to_ix = spl_token_2022::instruction::mint_to(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        &sender_token_account,
+        &payer.pubkey(),
+        &[],
+        funding,
+    )?;
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[mint_to_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+
+    println!("💰 Depositing to confidential balance + applying pending...");
+    deposit::deposit_to_confidential(&client, &payer, &sender, &mint.pubkey(), funding, DECIMALS)
+        .await?;
+    apply_pending::apply_pending_balance(&client, &payer, &sender, &mint.pubkey()).await?;
+    print_available(&client, "sender", &sender, &mint.pubkey())?;
+
+    println!("\n🎫 Configuring {num_recipients} recipients...");
+    let mut recipients = Vec::with_capacity(num_recipients);
+    for i in 0..num_recipients {
+        let recipient = Keypair::new();
+        create_and_configure(&client, &payer, &recipient, &mint.pubkey()).await?;
+        println!("   recipient {}: {}", i + 1, recipient.pubkey());
+        recipients.push(recipient);
+    }
+
+    Ok(Scenario {
+        client,
+        payer,
+        sender,
+        mint: mint.pubkey(),
+        recipients,
+    })
+}

--- a/examples/get_balances.rs
+++ b/examples/get_balances.rs
@@ -27,7 +27,6 @@ use solana_zk_sdk::encryption::{
     auth_encryption::{AeCiphertext, AeKey},
     elgamal::{ElGamalCiphertext, ElGamalKeypair},
 };
-use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use serde_json;
 use spl_token_2022::{
@@ -108,22 +107,12 @@ fn get_balances(
     println!("\n💵 Public Balance (visible to all): {}", public_balance);
 
     // 2. Decrypt pending balance (ElGamal encrypted, split into lo/hi).
-    //    The on-chain ciphertexts are 4.0 PODs; byte-cast to 6.0.1 PODs for
-    //    decryption with our 6.0.1 ElGamal key.
-    let pending_lo_pod = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.pending_balance_lo)
-            .try_into()
-            .map_err(|_| "pending_balance_lo size")?,
-    );
-    let pending_hi_pod = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.pending_balance_hi)
-            .try_into()
-            .map_err(|_| "pending_balance_hi size")?,
-    );
-    let pending_lo: ElGamalCiphertext = pending_lo_pod
+    let pending_lo: ElGamalCiphertext = ct_extension
+        .pending_balance_lo
         .try_into()
         .map_err(|e| format!("decode pending_lo: {e:?}"))?;
-    let pending_hi: ElGamalCiphertext = pending_hi_pod
+    let pending_hi: ElGamalCiphertext = ct_extension
+        .pending_balance_hi
         .try_into()
         .map_err(|e| format!("decode pending_hi: {e:?}"))?;
 
@@ -141,12 +130,8 @@ fn get_balances(
     println!("   Combined:  {}", pending_total);
 
     // 3. Decrypt available balance (ElGamal encrypted).
-    let available_pod = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.available_balance)
-            .try_into()
-            .map_err(|_| "available_balance size")?,
-    );
-    let available_balance_elgamal: ElGamalCiphertext = available_pod
+    let available_balance_elgamal: ElGamalCiphertext = ct_extension
+        .available_balance
         .try_into()
         .map_err(|e| format!("decode available_balance: {e:?}"))?;
 
@@ -154,11 +139,10 @@ fn get_balances(
         .ok_or("Failed to decrypt available_balance with ElGamal")?;
 
     // 4. Also decrypt using the AES-encrypted decryptable balance (cheaper).
-    let decryptable_bytes: [u8; 36] = bytemuck::bytes_of(&ct_extension.decryptable_available_balance)
+    let decryptable_balance: AeCiphertext = ct_extension
+        .decryptable_available_balance
         .try_into()
-        .map_err(|_| "decryptable_available_balance size")?;
-    let decryptable_balance =
-        AeCiphertext::from_bytes(&decryptable_bytes).ok_or("decode AeCiphertext")?;
+        .map_err(|e| format!("decode AeCiphertext: {e:?}"))?;
 
     let available_aes = aes_key.decrypt(&decryptable_balance)
         .ok_or("Failed to decrypt decryptable_available_balance with AES")?;

--- a/examples/get_balances.rs
+++ b/examples/get_balances.rs
@@ -8,163 +8,18 @@
 //!
 //! Usage (environment variables):
 //! MINT_ADDRESS=<mint> OWNER_KEYPAIR=$(cat ~/.config/solana/id.json) cargo run --example get_balances
-//!
-//! Example:
-//! cargo run --example get_balances -- TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA ~/.config/solana/id.json
-//!
-//! Or with environment variables:
-//! MINT_ADDRESS=TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA \
-//! OWNER_KEYPAIR=$(cat ~/.config/solana/id.json) \
-//! cargo run --example get_balances
 
+use conf_balances_examples::balances::{read_available_elgamal, read_balances, Balances};
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_pubkey::Pubkey;
 use solana_keypair::{read_keypair_file, Keypair};
+use solana_pubkey::Pubkey;
 use solana_signer::Signer;
-use solana_zk_sdk::encryption::{
-    auth_encryption::{AeCiphertext, AeKey},
-    elgamal::{ElGamalCiphertext, ElGamalKeypair},
-};
-use spl_associated_token_account::get_associated_token_address_with_program_id;
-use serde_json;
-use spl_token_2022::{
-    extension::{
-        confidential_transfer::ConfidentialTransferAccount, BaseStateWithExtensions,
-        StateWithExtensions,
-    },
-    state::Account as TokenAccount,
-};
 use std::env;
 
-#[derive(Debug)]
-struct BalanceBreakdown {
-    pub public: u64,
-    pub pending: u64,
-    pub available: u64,
-    pub total: u64,
-}
-
-/// Get all balance types for a confidential token account
-fn get_balances(
-    client: &RpcClient,
-    owner: &Keypair,
-    mint: &Pubkey,
-) -> Result<BalanceBreakdown, Box<dyn std::error::Error>> {
-    let token_account = get_associated_token_address_with_program_id(
-        &owner.pubkey(),
-        mint,
-        &spl_token_2022::id(),
-    );
-
-    println!("🔍 Fetching account: {}", token_account);
-
-    // Derive encryption keys from owner
-    let elgamal_keypair = ElGamalKeypair::new_from_signer(
-        owner,
-        &token_account.to_bytes(),
-    )?;
-    let aes_key = AeKey::new_from_signer(
-        owner,
-        &token_account.to_bytes(),
-    )?;
-
-    println!("🔑 Derived encryption keys from owner signature");
-
-    // Fetch account data
-    let account_data = match client.get_account(&token_account) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("\n❌ Error fetching token account: {}", e);
-            eprintln!("\nPossible reasons:");
-            eprintln!("  1. Token account doesn't exist yet");
-            eprintln!("  2. Wrong mint address");
-            eprintln!("  3. Wrong owner keypair");
-            eprintln!("  4. Account not configured for this mint");
-            eprintln!("\nTo create a token account:");
-            eprintln!("  spl-token create-account {} --owner {}", mint, owner.pubkey());
-            return Err(e.into());
-        }
-    };
-
-    let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
-
-    println!("\n📦 Account info:");
-    println!("   Mint: {}", account.base.mint);
-    println!("   Owner: {}", account.base.owner);
-
-    let ct_extension = account.get_extension::<ConfidentialTransferAccount>()?;
-
-    println!("\n🔐 Confidential Transfer Extension:");
-    println!("   Approved: {}", bool::from(ct_extension.approved));
-    println!("   Allow confidential credits: {}", bool::from(ct_extension.allow_confidential_credits));
-    println!("   Allow non-confidential credits: {}", bool::from(ct_extension.allow_non_confidential_credits));
-    println!("   Pending balance credit counter: {}", u64::from(ct_extension.pending_balance_credit_counter));
-
-    // 1. Public balance (not encrypted)
-    let public_balance = account.base.amount;
-    println!("\n💵 Public Balance (visible to all): {}", public_balance);
-
-    // 2. Decrypt pending balance (ElGamal encrypted, split into lo/hi).
-    let pending_lo: ElGamalCiphertext = ct_extension
-        .pending_balance_lo
-        .try_into()
-        .map_err(|e| format!("decode pending_lo: {e:?}"))?;
-    let pending_hi: ElGamalCiphertext = ct_extension
-        .pending_balance_hi
-        .try_into()
-        .map_err(|e| format!("decode pending_hi: {e:?}"))?;
-
-    let pending_lo_amount = pending_lo.decrypt_u32(elgamal_keypair.secret())
-        .ok_or("Failed to decrypt pending_balance_lo")?;
-    let pending_hi_amount = pending_hi.decrypt_u32(elgamal_keypair.secret())
-        .ok_or("Failed to decrypt pending_balance_hi")?;
-
-    // Combine lo and hi parts (pending is split for range proofs)
-    let pending_total = pending_lo_amount + (pending_hi_amount << 16);
-
-    println!("\n🔓 Pending Balance (ElGamal decrypted):");
-    println!("   Low bits:  {} (decrypted with ElGamal secret key)", pending_lo_amount);
-    println!("   High bits: {} (decrypted with ElGamal secret key)", pending_hi_amount);
-    println!("   Combined:  {}", pending_total);
-
-    // 3. Decrypt available balance (ElGamal encrypted).
-    let available_balance_elgamal: ElGamalCiphertext = ct_extension
-        .available_balance
-        .try_into()
-        .map_err(|e| format!("decode available_balance: {e:?}"))?;
-
-    let available_elgamal = available_balance_elgamal.decrypt_u32(elgamal_keypair.secret())
-        .ok_or("Failed to decrypt available_balance with ElGamal")?;
-
-    // 4. Also decrypt using the AES-encrypted decryptable balance (cheaper).
-    let decryptable_balance: AeCiphertext = ct_extension
-        .decryptable_available_balance
-        .try_into()
-        .map_err(|e| format!("decode AeCiphertext: {e:?}"))?;
-
-    let available_aes = aes_key.decrypt(&decryptable_balance)
-        .ok_or("Failed to decrypt decryptable_available_balance with AES")?;
-
-    println!("\n🔓 Available Balance:");
-    println!("   ElGamal decryption: {} (using ElGamal secret key)", available_elgamal);
-    println!("   AES decryption:     {} (using AES key - faster!)", available_aes);
-    println!("   Match: {}", available_elgamal == available_aes);
-
-    let total = public_balance + pending_total + available_aes;
-
-    Ok(BalanceBreakdown {
-        public: public_balance,
-        pending: pending_total,
-        available: available_aes,
-        total,
-    })
-}
-
-/// Display balances in a formatted way
-fn display_balances(balances: &BalanceBreakdown, decimals: u8) {
+/// Display balances in a formatted way.
+fn display_balances(balances: &Balances, decimals: u8) {
     let divisor = 10_u64.pow(decimals as u32) as f64;
-
     println!("\n╔══════════════════════════════════════════╗");
     println!("║           BALANCE BREAKDOWN              ║");
     println!("╠══════════════════════════════════════════╣");
@@ -173,7 +28,7 @@ fn display_balances(balances: &BalanceBreakdown, decimals: u8) {
     println!("║  Pending Balance:   {:>12.9} tokens  ║", balances.pending as f64 / divisor);
     println!("║  Available Balance: {:>12.9} tokens  ║", balances.available as f64 / divisor);
     println!("║  ──────────────────────────────────────  ║");
-    println!("║  Total:             {:>12.9} tokens  ║", balances.total as f64 / divisor);
+    println!("║  Total:             {:>12.9} tokens  ║", balances.total() as f64 / divisor);
     println!("║                                          ║");
     println!("╚══════════════════════════════════════════╝");
 
@@ -186,7 +41,6 @@ fn display_balances(balances: &BalanceBreakdown, decimals: u8) {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
 
-    // Get mint address (from args or env var)
     let mint_str = if args.len() >= 2 {
         args[1].clone()
     } else if let Ok(mint_env) = env::var("MINT_ADDRESS") {
@@ -195,59 +49,49 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("Error: MINT_ADDRESS not provided");
         eprintln!("\nUsage (args):    {} <MINT_ADDRESS> <OWNER_KEYPAIR_PATH>", args[0]);
         eprintln!("Usage (env):     MINT_ADDRESS=<mint> OWNER_KEYPAIR=<json> {}", args[0]);
-        eprintln!("\nExample (args):  {} TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA ~/.config/solana/id.json", args[0]);
-        eprintln!("Example (env):   MINT_ADDRESS=TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA OWNER_KEYPAIR=$(cat ~/.config/solana/id.json) {}", args[0]);
         std::process::exit(1);
     };
+    let mint = mint_str
+        .parse::<Pubkey>()
+        .map_err(|_| format!("Invalid mint address: {mint_str}"))?;
 
-    // Parse mint address
-    let mint = mint_str.parse::<Pubkey>()
-        .map_err(|_| format!("Invalid mint address: {}", mint_str))?;
-
-    // Load owner keypair (from args, env var as path, or env var as JSON)
+    // Owner keypair from a file-path arg, or OWNER_KEYPAIR env as a JSON array.
     let owner = if args.len() >= 3 {
-        // From command line argument (file path)
-        let keypair_path = &args[2];
-        read_keypair_file(keypair_path)
-            .map_err(|e| format!("Failed to read keypair from {}: {}", keypair_path, e))?
+        read_keypair_file(&args[2])
+            .map_err(|e| format!("Failed to read keypair from {}: {e}", args[2]))?
     } else if let Ok(keypair_json) = env::var("OWNER_KEYPAIR") {
-        // From environment variable (JSON array)
         let bytes: Vec<u8> = serde_json::from_str(&keypair_json)
-            .map_err(|e| format!("Failed to parse OWNER_KEYPAIR as JSON: {}", e))?;
-
+            .map_err(|e| format!("Failed to parse OWNER_KEYPAIR as JSON: {e}"))?;
         if bytes.len() != 64 {
             return Err(format!("Invalid keypair: expected 64 bytes, got {}", bytes.len()).into());
         }
-
-        // Extract first 32 bytes (secret key)
         let mut secret_key = [0u8; 32];
         secret_key.copy_from_slice(&bytes[0..32]);
         Keypair::new_from_array(secret_key)
     } else {
-        eprintln!("Error: Owner keypair not provided");
-        eprintln!("\nProvide keypair via:");
-        eprintln!("  1. Command line arg:  <OWNER_KEYPAIR_PATH>");
-        eprintln!("  2. Environment var:   OWNER_KEYPAIR=$(cat ~/.config/solana/id.json)");
+        eprintln!("Error: Owner keypair not provided (arg path or OWNER_KEYPAIR env)");
         std::process::exit(1);
     };
 
-    // Connect to RPC
-    let rpc_url = env::var("SOLANA_RPC_URL")
-        .unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
-
-    println!("🔗 Connecting to: {}", rpc_url);
+    let rpc_url =
+        env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
+    println!("🔗 Connecting to: {rpc_url}");
     let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
 
     println!("👤 Owner: {}", owner.pubkey());
-    println!("🪙 Mint: {}\n", mint);
+    println!("🪙 Mint: {mint}\n", );
 
-    // Get balances
-    let balances = get_balances(&client, &owner, &mint)?;
+    let balances = read_balances(&client, &owner, &mint)?;
 
-    // Display formatted
-    display_balances(&balances, 9); // Assuming 9 decimals
+    // Cross-check the available balance via the (slower) ElGamal path.
+    let available_elgamal = read_available_elgamal(&client, &owner, &mint)?;
+    println!("🔓 Available balance decryption:");
+    println!("   AES:     {} (fast path)", balances.available);
+    println!("   ElGamal: {available_elgamal}");
+    println!("   Match:   {}", balances.available == available_elgamal);
+
+    display_balances(&balances, 9);
 
     println!("\n✅ Balance query complete!");
-
     Ok(())
 }

--- a/examples/get_balances.rs
+++ b/examples/get_balances.rs
@@ -19,10 +19,9 @@
 
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{read_keypair_file, Keypair, Signer},
-};
+use solana_pubkey::Pubkey;
+use solana_keypair::{read_keypair_file, Keypair};
+use solana_signer::Signer;
 use solana_zk_sdk::encryption::{
     auth_encryption::{AeCiphertext, AeKey},
     elgamal::{ElGamalCiphertext, ElGamalKeypair},

--- a/examples/run_transfer.rs
+++ b/examples/run_transfer.rs
@@ -15,7 +15,6 @@ use solana_zk_sdk::encryption::{
     auth_encryption::{AeCiphertext, AeKey},
     elgamal::{ElGamalCiphertext, ElGamalKeypair},
 };
-use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
     extension::{
@@ -58,21 +57,12 @@ fn display_balances(
     // Public balance
     let public_balance = account.base.amount;
 
-    // 4.0 POD ciphertexts on chain → 6.0.1 PODs via byte cast → ElGamalCiphertext.
-    let pending_lo_pod = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.pending_balance_lo)
-            .try_into()
-            .map_err(|_| "pending_balance_lo size")?,
-    );
-    let pending_hi_pod = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.pending_balance_hi)
-            .try_into()
-            .map_err(|_| "pending_balance_hi size")?,
-    );
-    let pending_lo: ElGamalCiphertext = pending_lo_pod
+    let pending_lo: ElGamalCiphertext = ct_extension
+        .pending_balance_lo
         .try_into()
         .map_err(|e| format!("decode pending_lo: {e:?}"))?;
-    let pending_hi: ElGamalCiphertext = pending_hi_pod
+    let pending_hi: ElGamalCiphertext = ct_extension
+        .pending_balance_hi
         .try_into()
         .map_err(|e| format!("decode pending_hi: {e:?}"))?;
 
@@ -85,11 +75,10 @@ fn display_balances(
     let pending_total = pending_lo_amount + (pending_hi_amount << 16);
 
     // Decrypt available balance using AES (cheap relative to ElGamal DLP).
-    let avail_aes_bytes: [u8; 36] = bytemuck::bytes_of(&ct_extension.decryptable_available_balance)
+    let decryptable_balance: AeCiphertext = ct_extension
+        .decryptable_available_balance
         .try_into()
-        .map_err(|_| "decryptable_available_balance size")?;
-    let decryptable_balance =
-        AeCiphertext::from_bytes(&avail_aes_bytes).ok_or("decode AeCiphertext")?;
+        .map_err(|e| format!("decode AeCiphertext: {e:?}"))?;
     let available_balance = aes_key.decrypt(&decryptable_balance).unwrap_or(0);
 
     // Format amounts with decimals
@@ -148,11 +137,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mint = {
         use solana_sdk::transaction::Transaction;
         use solana_system_interface::instruction as system_instruction;
-        use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey as PodElGamalPubkeyV6;
+        use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
         use spl_token_2022::{
             extension::{confidential_transfer::instruction::initialize_mint, ExtensionType},
             instruction::initialize_mint as initialize_mint_base,
-            solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey as PodElGamalPubkeyLegacy,
             state::Mint,
         };
 
@@ -162,11 +150,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ])?;
         let rent = client.get_minimum_balance_for_rent_exemption(space)?;
 
-        // Auditor key derived in 6.0.1; the on-chain mint stores it as the
-        // legacy PodElGamalPubkey type (identical wire format, byte-cast).
         let auditor_elgamal = ElGamalKeypair::new_rand();
-        let auditor_pod_v6: PodElGamalPubkeyV6 = (*auditor_elgamal.pubkey()).into();
-        let auditor_pubkey_pod = PodElGamalPubkeyLegacy::from(auditor_pod_v6.0);
+        let auditor_pubkey_pod: PodElGamalPubkey = (*auditor_elgamal.pubkey()).into();
 
         let create_account_ix = system_instruction::create_account(
             &payer.pubkey(),

--- a/examples/run_transfer.rs
+++ b/examples/run_transfer.rs
@@ -4,126 +4,55 @@
 //! Usage:
 //! SOLANA_RPC_URL=https://api.devnet.solana.com PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) cargo run --example run_transfer
 
-use conf_balances_examples::*;
+use conf_balances_examples::balances::read_balances;
+use conf_balances_examples::setup::{
+    create_and_configure_account, create_confidential_mint, load_keypair_env,
+};
+use conf_balances_examples::{apply_pending, deposit, transfer};
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_native_token::LAMPORTS_PER_SOL;
 use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_pubkey::Pubkey;
 use solana_signer::Signer;
-use solana_zk_sdk::encryption::{
-    auth_encryption::{AeCiphertext, AeKey},
-    elgamal::{ElGamalCiphertext, ElGamalKeypair},
-};
+use solana_transaction::Transaction;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
-use spl_token_2022::{
-    extension::{
-        confidential_transfer::ConfidentialTransferAccount, BaseStateWithExtensions,
-        StateWithExtensions,
-    },
-    state::Account as TokenAccount,
-};
 use std::env;
 
-/// Display all balance types for a token account
+const DECIMALS: u8 = 9;
+
+/// Decrypt and display public / pending / available balances for an account.
 fn display_balances(
     client: &RpcClient,
     account_name: &str,
     owner: &Keypair,
-    mint: &solana_pubkey::Pubkey,
-    decimals: u8,
+    mint: &Pubkey,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let token_account = get_associated_token_address_with_program_id(
-        &owner.pubkey(),
-        mint,
-        &spl_token_2022::id(),
-    );
-
-    // Derive encryption keys
-    let elgamal_keypair = ElGamalKeypair::new_from_signer(
-        owner,
-        &token_account.to_bytes(),
-    )?;
-    let aes_key = AeKey::new_from_signer(
-        owner,
-        &token_account.to_bytes(),
-    )?;
-
-    // Fetch account data
-    let account_data = client.get_account(&token_account)?;
-    let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
-    let ct_extension = account.get_extension::<ConfidentialTransferAccount>()?;
-
-    // Public balance
-    let public_balance = account.base.amount;
-
-    let pending_lo: ElGamalCiphertext = ct_extension
-        .pending_balance_lo
-        .try_into()
-        .map_err(|e| format!("decode pending_lo: {e:?}"))?;
-    let pending_hi: ElGamalCiphertext = ct_extension
-        .pending_balance_hi
-        .try_into()
-        .map_err(|e| format!("decode pending_hi: {e:?}"))?;
-
-    let pending_lo_amount = pending_lo
-        .decrypt_u32(elgamal_keypair.secret())
-        .unwrap_or(0);
-    let pending_hi_amount = pending_hi
-        .decrypt_u32(elgamal_keypair.secret())
-        .unwrap_or(0);
-    let pending_total = pending_lo_amount + (pending_hi_amount << 16);
-
-    // Decrypt available balance using AES (cheap relative to ElGamal DLP).
-    let decryptable_balance: AeCiphertext = ct_extension
-        .decryptable_available_balance
-        .try_into()
-        .map_err(|e| format!("decode AeCiphertext: {e:?}"))?;
-    let available_balance = aes_key.decrypt(&decryptable_balance).unwrap_or(0);
-
-    // Format amounts with decimals
-    let divisor = 10_u64.pow(decimals as u32) as f64;
-    let public_formatted = public_balance as f64 / divisor;
-    let pending_formatted = pending_total as f64 / divisor;
-    let available_formatted = available_balance as f64 / divisor;
-    let total = (public_balance + pending_total + available_balance) as f64 / divisor;
-
-    println!("\n📊 {} Balance:", account_name);
-    println!("   Public:    {:>12.9} tokens", public_formatted);
-    println!("   Pending:   {:>12.9} tokens", pending_formatted);
-    println!("   Available: {:>12.9} tokens", available_formatted);
+    let b = read_balances(client, owner, mint)?;
+    let divisor = 10_u64.pow(DECIMALS as u32) as f64;
+    println!("\n📊 {account_name} Balance:");
+    println!("   Public:    {:>12.9} tokens", b.public as f64 / divisor);
+    println!("   Pending:   {:>12.9} tokens", b.pending as f64 / divisor);
+    println!("   Available: {:>12.9} tokens", b.available as f64 / divisor);
     println!("   ─────────────────────────────");
-    println!("   Total:     {:>12.9} tokens", total);
-
+    println!("   Total:     {:>12.9} tokens", b.total() as f64 / divisor);
     Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Get RPC URL
-    let rpc_url = env::var("SOLANA_RPC_URL")
-        .unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
-
-    println!("🔗 Connecting to: {}", rpc_url);
-
+    let rpc_url =
+        env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
+    println!("🔗 Connecting to: {rpc_url}");
     let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
 
-    // Load payer from environment
-    let payer = if let Ok(keypair_json) = env::var("PAYER_KEYPAIR") {
-        let bytes: Vec<u8> = serde_json::from_str(&keypair_json)?;
-        if bytes.len() != 64 {
-            return Err(format!("Invalid keypair: expected 64 bytes, got {}", bytes.len()).into());
-        }
-        let mut secret_key = [0u8; 32];
-        secret_key.copy_from_slice(&bytes[0..32]);
-        Keypair::new_from_array(secret_key)
-    } else {
-        return Err("PAYER_KEYPAIR environment variable not set".into());
-    };
-
+    let payer = load_keypair_env("PAYER_KEYPAIR")?;
     println!("💰 Payer: {}", payer.pubkey());
-    println!("💳 Balance: {} SOL", client.get_balance(&payer.pubkey())? as f64 / LAMPORTS_PER_SOL as f64);
+    println!(
+        "💳 Balance: {} SOL",
+        client.get_balance(&payer.pubkey())? as f64 / LAMPORTS_PER_SOL as f64
+    );
 
-    // Create user accounts
     let sender = &payer;
     let recipient = Keypair::new();
 
@@ -131,113 +60,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  Sender: {}", sender.pubkey());
     println!("  Recipient: {}", recipient.pubkey());
 
-    // Create confidential mint
     println!("\n🏭 Creating confidential mint...");
-    let mint = {
-        use solana_transaction::Transaction;
-        use solana_system_interface::instruction as system_instruction;
-        use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
-        use spl_token_2022::{
-            extension::{confidential_transfer::instruction::initialize_mint, ExtensionType},
-            instruction::initialize_mint as initialize_mint_base,
-            state::Mint,
-        };
+    let mint = create_confidential_mint(&client, &payer, DECIMALS)?;
+    println!("  Mint: {}", mint.pubkey());
 
-        let mint = Keypair::new();
-        let space = ExtensionType::try_calculate_account_len::<Mint>(&[
-            ExtensionType::ConfidentialTransferMint,
-        ])?;
-        let rent = client.get_minimum_balance_for_rent_exemption(space)?;
-
-        let auditor_elgamal = ElGamalKeypair::new_rand();
-        let auditor_pubkey_pod: PodElGamalPubkey = (*auditor_elgamal.pubkey()).into();
-
-        let create_account_ix = system_instruction::create_account(
-            &payer.pubkey(),
-            &mint.pubkey(),
-            rent,
-            space as u64,
-            &spl_token_2022::id(),
-        );
-
-        let init_ct_ix = initialize_mint(
-            &spl_token_2022::id(),
-            &mint.pubkey(),
-            None,
-            true,
-            Some(auditor_pubkey_pod),
-        )?;
-
-        let init_mint_ix = initialize_mint_base(
-            &spl_token_2022::id(),
-            &mint.pubkey(),
-            &payer.pubkey(),
-            None,
-            9,
-        )?;
-
-        let recent_blockhash = client.get_latest_blockhash()?;
-        let transaction = Transaction::new_signed_with_payer(
-            &[create_account_ix, init_ct_ix, init_mint_ix],
-            Some(&payer.pubkey()),
-            &[&payer, &mint],
-            recent_blockhash,
-        );
-
-        client.send_and_confirm_transaction(&transaction)?;
-        println!("  Mint: {}", mint.pubkey());
-        mint
-    };
-
-    // Create token accounts
-    println!("\n🎫 Creating token accounts...");
-    use spl_associated_token_account::{get_associated_token_address_with_program_id, instruction::create_associated_token_account};
+    println!("\n🎫 Creating + configuring token accounts...");
+    create_and_configure_account(&client, &payer, sender, &mint.pubkey()).await?;
+    create_and_configure_account(&client, &payer, &recipient, &mint.pubkey()).await?;
 
     let sender_token_account = get_associated_token_address_with_program_id(
         &sender.pubkey(),
         &mint.pubkey(),
         &spl_token_2022::id(),
     );
-
     let recipient_token_account = get_associated_token_address_with_program_id(
         &recipient.pubkey(),
         &mint.pubkey(),
         &spl_token_2022::id(),
     );
+    println!("  Sender token account: {sender_token_account}");
+    println!("  Recipient token account: {recipient_token_account}");
 
-    let create_sender_ata = create_associated_token_account(
-        &payer.pubkey(),
-        &sender.pubkey(),
-        &mint.pubkey(),
-        &spl_token_2022::id(),
-    );
-
-    let create_recipient_ata = create_associated_token_account(
-        &payer.pubkey(),
-        &recipient.pubkey(),
-        &mint.pubkey(),
-        &spl_token_2022::id(),
-    );
-
-    use solana_transaction::Transaction;
-    let recent_blockhash = client.get_latest_blockhash()?;
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_sender_ata, create_recipient_ata],
-        Some(&payer.pubkey()),
-        &[&payer],
-        recent_blockhash,
-    );
-    client.send_and_confirm_transaction(&transaction)?;
-
-    println!("  Sender token account: {}", sender_token_account);
-    println!("  Recipient token account: {}", recipient_token_account);
-
-    // Configure accounts
-    println!("\n⚙️  Configuring accounts for confidential transfers...");
-    configure::configure_account_for_confidential_transfers(&client, &payer, &sender, &mint.pubkey()).await?;
-    configure::configure_account_for_confidential_transfers(&client, &payer, &recipient, &mint.pubkey()).await?;
-
-    // Mint tokens
     println!("\n🪙 Minting tokens to sender...");
     let mint_to_ix = spl_token_2022::instruction::mint_to(
         &spl_token_2022::id(),
@@ -247,7 +90,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &[],
         1_000_000_000,
     )?;
-
     let recent_blockhash = client.get_latest_blockhash()?;
     let transaction = Transaction::new_signed_with_payer(
         &[mint_to_ix],
@@ -257,61 +99,61 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     client.send_and_confirm_transaction(&transaction)?;
 
-    // Show initial balances
-    display_balances(&client, "Sender (after mint)", &sender, &mint.pubkey(), 9)?;
-    display_balances(&client, "Recipient (initial)", &recipient, &mint.pubkey(), 9)?;
+    display_balances(&client, "Sender (after mint)", sender, &mint.pubkey())?;
+    display_balances(&client, "Recipient (initial)", &recipient, &mint.pubkey())?;
 
-    // Deposit to confidential
     println!("\n💰 Depositing to confidential balance...");
-    deposit::deposit_to_confidential(&client, &payer, &sender, &mint.pubkey(), 800_000_000, 9).await?;
-    display_balances(&client, "Sender (after deposit)", &sender, &mint.pubkey(), 9)?;
+    deposit::deposit_to_confidential(&client, &payer, sender, &mint.pubkey(), 800_000_000, DECIMALS)
+        .await?;
+    display_balances(&client, "Sender (after deposit)", sender, &mint.pubkey())?;
 
-    // Apply pending
     println!("\n🔄 Applying pending balance...");
-    apply_pending::apply_pending_balance(&client, &payer, &sender, &mint.pubkey()).await?;
-    display_balances(&client, "Sender (after apply)", &sender, &mint.pubkey(), 9)?;
+    apply_pending::apply_pending_balance(&client, &payer, sender, &mint.pubkey()).await?;
+    display_balances(&client, "Sender (after apply)", sender, &mint.pubkey())?;
 
-    // Transfer confidentially
     println!("\n🔐 Executing confidential transfer...");
-    println!("   This will create 7 transactions:");
-    println!("   - 3 proof context state account creations");
-    println!("   - 1 confidential transfer");
-    println!("   - 3 proof account closures");
+    println!("   This will create 3 transactions:");
+    println!("   - proof account creations + validity proof verification");
+    println!("   - range proof verification");
+    println!("   - equality proof verification + transfer + proof account closures");
 
     let signatures = transfer::transfer_confidential(
         &client,
         &payer,
-        &sender,
+        sender,
         &mint.pubkey(),
         &recipient.pubkey(),
         50_000_000,
-    ).await?;
+    )
+    .await?;
 
     println!("\n✅ Confidential transfer complete!");
+    display_balances(&client, "Sender (after transfer)", sender, &mint.pubkey())?;
+    display_balances(
+        &client,
+        "Recipient (after transfer - before apply)",
+        &recipient,
+        &mint.pubkey(),
+    )?;
 
-    // Show balances after transfer
-    display_balances(&client, "Sender (after transfer)", &sender, &mint.pubkey(), 9)?;
-    display_balances(&client, "Recipient (after transfer - before apply)", &recipient, &mint.pubkey(), 9)?;
-
-    // Recipient applies pending balance
     println!("\n🔄 Recipient applying pending balance...");
     apply_pending::apply_pending_balance(&client, &payer, &recipient, &mint.pubkey()).await?;
-    display_balances(&client, "Recipient (after apply)", &recipient, &mint.pubkey(), 9)?;
+    display_balances(&client, "Recipient (after apply)", &recipient, &mint.pubkey())?;
 
     println!("\n📝 Transaction signatures:");
     for (i, sig) in signatures.iter().enumerate() {
         println!("   {}. {}", i + 1, sig);
     }
 
-    println!("\n🔗 View on explorer:");
-    println!("   https://explorer.solana.com/tx/{}?cluster=custom&customUrl=https%3A%2F%2Fzk-edge.surfnet.dev%3A8899", signatures[3]);
-
     println!("\n📋 Account Addresses (for querying balances):");
-    println!("   Mint:                   {}", mint.pubkey());
-    println!("   Sender token account:   {}", sender_token_account);
-    println!("   Recipient token account: {}", recipient_token_account);
+    println!("   Mint:                    {}", mint.pubkey());
+    println!("   Sender token account:    {sender_token_account}");
+    println!("   Recipient token account: {recipient_token_account}");
     println!("\n💡 Query balances with:");
-    println!("   MINT_ADDRESS={} OWNER_KEYPAIR=</path/to/owner/keypair.json> cargo run --example get_balances", mint.pubkey());
+    println!(
+        "   MINT_ADDRESS={} OWNER_KEYPAIR=</path/to/owner/keypair.json> cargo run --example get_balances",
+        mint.pubkey()
+    );
 
     Ok(())
 }

--- a/examples/run_transfer.rs
+++ b/examples/run_transfer.rs
@@ -7,10 +7,9 @@
 use conf_balances_examples::*;
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_sdk::{
-    native_token::LAMPORTS_PER_SOL,
-    signature::{Keypair, Signer},
-};
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
 use solana_zk_sdk::encryption::{
     auth_encryption::{AeCiphertext, AeKey},
     elgamal::{ElGamalCiphertext, ElGamalKeypair},
@@ -30,7 +29,7 @@ fn display_balances(
     client: &RpcClient,
     account_name: &str,
     owner: &Keypair,
-    mint: &solana_sdk::pubkey::Pubkey,
+    mint: &solana_pubkey::Pubkey,
     decimals: u8,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let token_account = get_associated_token_address_with_program_id(
@@ -135,7 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create confidential mint
     println!("\n🏭 Creating confidential mint...");
     let mint = {
-        use solana_sdk::transaction::Transaction;
+        use solana_transaction::Transaction;
         use solana_system_interface::instruction as system_instruction;
         use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
         use spl_token_2022::{
@@ -220,7 +219,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &spl_token_2022::id(),
     );
 
-    use solana_sdk::transaction::Transaction;
+    use solana_transaction::Transaction;
     let recent_blockhash = client.get_latest_blockhash()?;
     let transaction = Transaction::new_signed_with_payer(
         &[create_sender_ata, create_recipient_ata],

--- a/examples/run_transfer_with_fees.rs
+++ b/examples/run_transfer_with_fees.rs
@@ -1,0 +1,267 @@
+//! Example: Confidential transfer on a mint with transfer fees and a
+//! permanent delegate.
+//!
+//! Demonstrates the three extensions working together:
+//! * `TransferFeeConfig` + `ConfidentialTransferFeeConfig`: a 1% fee (capped)
+//!   is withheld on the recipient account, encrypted under the withdraw-
+//!   withheld authority's ElGamal key, then harvested to the mint.
+//! * `PermanentDelegate`: the delegate burns tokens from the recipient's
+//!   public balance without the recipient signing.
+//!
+//! Usage:
+//! SOLANA_RPC_URL=https://api.devnet.solana.com PAYER_KEYPAIR=$(cat ~/.config/solana/id.json) cargo run --example run_transfer_with_fees
+
+use conf_balances_examples::balances::read_balances;
+use conf_balances_examples::setup::{
+    create_and_configure_fee_account, create_confidential_fee_mint, load_keypair_env,
+};
+use conf_balances_examples::{apply_pending, deposit, transfer_with_fee, withdraw};
+use solana_client::rpc_client::RpcClient;
+use solana_commitment_config::CommitmentConfig;
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use solana_zk_sdk::encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair};
+use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token_2022::{
+    extension::{
+        confidential_transfer_fee::{
+            instruction::harvest_withheld_tokens_to_mint, ConfidentialTransferFeeAmount,
+            ConfidentialTransferFeeConfig,
+        },
+        BaseStateWithExtensions, StateWithExtensions,
+    },
+    state::{Account as TokenAccount, Mint},
+};
+use std::env;
+
+const DECIMALS: u8 = 9;
+const FEE_BASIS_POINTS: u16 = 100; // 1%
+const MAXIMUM_FEE: u64 = 1_000_000;
+const TRANSFER_AMOUNT: u64 = 50_000_000;
+const EXPECTED_FEE: u64 = 500_000; // 1% of 50_000_000, under the cap
+
+/// Decrypt and display public / pending / available balances for an account.
+fn display_balances(
+    client: &RpcClient,
+    account_name: &str,
+    owner: &Keypair,
+    mint: &Pubkey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let b = read_balances(client, owner, mint)?;
+    let divisor = 10_u64.pow(DECIMALS as u32) as f64;
+    println!("\n📊 {account_name} Balance:");
+    println!("   Public:    {:>12.9} tokens", b.public as f64 / divisor);
+    println!("   Pending:   {:>12.9} tokens", b.pending as f64 / divisor);
+    println!("   Available: {:>12.9} tokens", b.available as f64 / divisor);
+    println!("   ─────────────────────────────");
+    println!("   Total:     {:>12.9} tokens", b.total() as f64 / divisor);
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rpc_url =
+        env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
+    println!("🔗 Connecting to: {rpc_url}");
+    let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+    let payer = load_keypair_env("PAYER_KEYPAIR")?;
+    println!("💰 Payer: {}", payer.pubkey());
+    println!(
+        "💳 Balance: {} SOL",
+        client.get_balance(&payer.pubkey())? as f64 / LAMPORTS_PER_SOL as f64
+    );
+
+    let sender = &payer;
+    let recipient = Keypair::new();
+
+    // The holder of this key can decrypt every withheld fee amount (and later
+    // withdraw accumulated fees). The example keeps it to verify the fee.
+    let withheld_authority_elgamal = ElGamalKeypair::new_rand();
+    let withheld_authority_pod: PodElGamalPubkey = (*withheld_authority_elgamal.pubkey()).into();
+
+    println!("\n🏭 Creating confidential mint with fees + permanent delegate...");
+    println!("   Fee: {FEE_BASIS_POINTS} bps, max {MAXIMUM_FEE} base units");
+    println!("   Permanent delegate: {} (payer)", payer.pubkey());
+    let mint = create_confidential_fee_mint(
+        &client,
+        &payer,
+        DECIMALS,
+        FEE_BASIS_POINTS,
+        MAXIMUM_FEE,
+        &withheld_authority_pod,
+        &payer.pubkey(),
+    )?;
+    println!("   Mint: {}", mint.pubkey());
+
+    println!("\n🎫 Creating + configuring token accounts (with fee extension)...");
+    create_and_configure_fee_account(&client, &payer, sender, &mint.pubkey()).await?;
+    create_and_configure_fee_account(&client, &payer, &recipient, &mint.pubkey()).await?;
+
+    let sender_token_account = get_associated_token_address_with_program_id(
+        &sender.pubkey(),
+        &mint.pubkey(),
+        &spl_token_2022::id(),
+    );
+    let recipient_token_account = get_associated_token_address_with_program_id(
+        &recipient.pubkey(),
+        &mint.pubkey(),
+        &spl_token_2022::id(),
+    );
+
+    println!("\n🪙 Minting tokens to sender...");
+    let mint_to_ix = spl_token_2022::instruction::mint_to(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        &sender_token_account,
+        &payer.pubkey(),
+        &[],
+        1_000_000_000,
+    )?;
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[mint_to_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+
+    println!("\n💰 Depositing to confidential balance + applying pending...");
+    deposit::deposit_to_confidential(&client, &payer, sender, &mint.pubkey(), 800_000_000, DECIMALS)
+        .await?;
+    apply_pending::apply_pending_balance(&client, &payer, sender, &mint.pubkey()).await?;
+    display_balances(&client, "Sender (after deposit + apply)", sender, &mint.pubkey())?;
+
+    println!("\n🔐 Executing confidential transfer with fee...");
+    let signatures = transfer_with_fee::transfer_confidential_with_fee(
+        &client,
+        &payer,
+        sender,
+        &mint.pubkey(),
+        &recipient.pubkey(),
+        TRANSFER_AMOUNT,
+    )
+    .await?;
+
+    display_balances(&client, "Sender (after transfer)", sender, &mint.pubkey())?;
+
+    println!("\n🔄 Recipient applying pending balance...");
+    apply_pending::apply_pending_balance(&client, &payer, &recipient, &mint.pubkey()).await?;
+    display_balances(&client, "Recipient (after apply)", &recipient, &mint.pubkey())?;
+    println!(
+        "\n   Recipient received {} net of the {} fee.",
+        TRANSFER_AMOUNT - EXPECTED_FEE,
+        EXPECTED_FEE
+    );
+
+    // ── Fee verification ──────────────────────────────────────────────────
+    println!("\n💸 Verifying the withheld confidential fee...");
+
+    // The withheld fee sits on the recipient account, encrypted under the
+    // withdraw-withheld authority's ElGamal key.
+    {
+        let account_data = client.get_account(&recipient_token_account)?;
+        let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
+        let fee_ext = account.get_extension::<ConfidentialTransferFeeAmount>()?;
+        let withheld: ElGamalCiphertext = fee_ext
+            .withheld_amount
+            .try_into()
+            .map_err(|e| format!("decode withheld_amount: {e:?}"))?;
+        let decrypted_fee = withheld
+            .decrypt_u32(withheld_authority_elgamal.secret())
+            .ok_or("decrypt withheld fee from recipient account")?;
+        println!("   Withheld on recipient account: {decrypted_fee} base units");
+        assert_eq!(decrypted_fee, EXPECTED_FEE);
+        println!("   ✅ Matches expected fee ({FEE_BASIS_POINTS} bps of {TRANSFER_AMOUNT})");
+    }
+
+    // Harvesting moves withheld fees from token accounts onto the mint. It is
+    // permissionless: anyone can crank it, since the amounts stay encrypted.
+    println!("\n   Harvesting withheld fees to the mint...");
+    let harvest_ix = harvest_withheld_tokens_to_mint(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        &[&recipient_token_account],
+    )?;
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[harvest_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
+    let harvest_sig = client.send_and_confirm_transaction(&tx)?;
+    println!("   Harvest tx: {harvest_sig}");
+
+    {
+        let mint_data = client.get_account(&mint.pubkey())?;
+        let mint_account = StateWithExtensions::<Mint>::unpack(&mint_data.data)?;
+        let ct_fee_config = mint_account.get_extension::<ConfidentialTransferFeeConfig>()?;
+        let withheld: ElGamalCiphertext = ct_fee_config
+            .withheld_amount
+            .try_into()
+            .map_err(|e| format!("decode mint withheld_amount: {e:?}"))?;
+        let decrypted_fee = withheld
+            .decrypt_u32(withheld_authority_elgamal.secret())
+            .ok_or("decrypt withheld fee from mint")?;
+        println!("   Withheld on mint after harvest: {decrypted_fee} base units");
+        assert_eq!(decrypted_fee, EXPECTED_FEE);
+        println!("   ✅ Fee successfully harvested to the mint");
+    }
+
+    // ── Permanent delegate ────────────────────────────────────────────────
+    println!("\n🔑 Verifying the permanent delegate...");
+
+    println!("   Recipient withdrawing 10,000,000 base units to public balance...");
+    withdraw::withdraw_from_confidential(
+        &client,
+        &payer,
+        &recipient,
+        &mint.pubkey(),
+        10_000_000,
+        DECIMALS,
+    )
+    .await?;
+    display_balances(&client, "Recipient (after withdraw)", &recipient, &mint.pubkey())?;
+
+    // The permanent delegate (payer) burns from the recipient's public
+    // balance. Only the delegate signs — the recipient does not.
+    println!("\n   Permanent delegate burning 5,000,000 base units from recipient...");
+    let burn_ix = spl_token_2022::instruction::burn_checked(
+        &spl_token_2022::id(),
+        &recipient_token_account,
+        &mint.pubkey(),
+        &payer.pubkey(),
+        &[],
+        5_000_000,
+        DECIMALS,
+    )?;
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[burn_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
+    let burn_sig = client.send_and_confirm_transaction(&tx)?;
+    println!("   Burn tx: {burn_sig}");
+    display_balances(&client, "Recipient (after delegate burn)", &recipient, &mint.pubkey())?;
+    println!("   ✅ Delegate burned from the recipient's account without their signature");
+
+    println!("\n📝 Transfer transaction signatures:");
+    for (i, sig) in signatures.iter().enumerate() {
+        println!("   {}. {}", i + 1, sig);
+    }
+
+    println!("\n📋 Account addresses:");
+    println!("   Mint:                    {}", mint.pubkey());
+    println!("   Sender token account:    {sender_token_account}");
+    println!("   Recipient token account: {recipient_token_account}");
+
+    Ok(())
+}

--- a/src/apply_pending.rs
+++ b/src/apply_pending.rs
@@ -7,7 +7,8 @@
 
 use crate::types::*;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::{signature::Signer, transaction::Transaction};
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use solana_zk_sdk::encryption::{
     auth_encryption::AeKey,
     elgamal::{ElGamalCiphertext, ElGamalKeypair},
@@ -29,7 +30,7 @@ pub async fn apply_pending_balance(
     client: &RpcClient,
     payer: &dyn Signer,
     authority: &dyn Signer,
-    mint: &solana_sdk::pubkey::Pubkey,
+    mint: &solana_pubkey::Pubkey,
 ) -> SigResult {
     let token_account = get_associated_token_address_with_program_id(
         &authority.pubkey(),

--- a/src/apply_pending.rs
+++ b/src/apply_pending.rs
@@ -1,15 +1,18 @@
 //! Apply pending balance to available balance.
 //!
-//! Decrypts pending + available balances using `solana-zk-sdk = 6.0.1` keys,
-//! re-encrypts the new available balance with AES, and submits the
-//! `ApplyPendingBalance` instruction. The new AES ciphertext is byte-cast to
-//! the legacy `PodAeCiphertext` type that `spl-token-2022 = 10.0.0` expects.
+//! Decrypts pending + available balances, re-encrypts the new available
+//! balance with AES, and submits the `ApplyPendingBalance` instruction. Every
+//! type is solana-zk-sdk 6.0.1, matching spl-token-2022 11.0.0's account
+//! layout directly.
 
 use crate::types::*;
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{signature::Signer, transaction::Transaction};
-use solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair};
-use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
+use solana_zk_sdk::encryption::{
+    auth_encryption::AeKey,
+    elgamal::{ElGamalCiphertext, ElGamalKeypair},
+};
+use solana_zk_sdk_pod::encryption::auth_encryption::PodAeCiphertext;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
     extension::{
@@ -19,7 +22,6 @@ use spl_token_2022::{
         },
         BaseStateWithExtensions, StateWithExtensions,
     },
-    solana_zk_sdk::encryption::pod::auth_encryption::PodAeCiphertext as PodAeCiphertextLegacy,
     state::Account as TokenAccount,
 };
 
@@ -43,29 +45,18 @@ pub async fn apply_pending_balance(
     let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
     let ct_extension = account.get_extension::<ConfidentialTransferAccount>()?;
 
-    // Byte-cast 4.0 PodElGamalCiphertext → 6.0.1 → ElGamalCiphertext.
-    let pending_lo_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.pending_balance_lo)
-            .try_into()
-            .map_err(|_| "pending_balance_lo size")?,
-    );
-    let pending_hi_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.pending_balance_hi)
-            .try_into()
-            .map_err(|_| "pending_balance_hi size")?,
-    );
-    let available_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.available_balance)
-            .try_into()
-            .map_err(|_| "available_balance size")?,
-    );
-
-    let pending_lo: solana_zk_sdk::encryption::elgamal::ElGamalCiphertext =
-        pending_lo_v6.try_into().map_err(|e| format!("{e:?}"))?;
-    let pending_hi: solana_zk_sdk::encryption::elgamal::ElGamalCiphertext =
-        pending_hi_v6.try_into().map_err(|e| format!("{e:?}"))?;
-    let available_balance: solana_zk_sdk::encryption::elgamal::ElGamalCiphertext =
-        available_v6.try_into().map_err(|e| format!("{e:?}"))?;
+    let pending_lo: ElGamalCiphertext = ct_extension
+        .pending_balance_lo
+        .try_into()
+        .map_err(|e| format!("pending_balance_lo: {e:?}"))?;
+    let pending_hi: ElGamalCiphertext = ct_extension
+        .pending_balance_hi
+        .try_into()
+        .map_err(|e| format!("pending_balance_hi: {e:?}"))?;
+    let available_balance: ElGamalCiphertext = ct_extension
+        .available_balance
+        .try_into()
+        .map_err(|e| format!("available_balance: {e:?}"))?;
 
     let pending_lo_amount = pending_lo
         .decrypt_u32(elgamal_keypair.secret())
@@ -80,11 +71,7 @@ pub async fn apply_pending_balance(
     let pending_total = pending_lo_amount + (pending_hi_amount << 16);
     let new_available = current_available + pending_total;
 
-    // Encrypt new available with 6.0.1 AES, byte-cast to legacy PodAeCiphertext
-    // for the spl-token-2022 instruction builder.
-    let new_decryptable_v6 = aes_key.encrypt(new_available as u64);
-    let new_decryptable_legacy: PodAeCiphertextLegacy =
-        PodAeCiphertextLegacy::from(new_decryptable_v6.to_bytes());
+    let new_decryptable: PodAeCiphertext = aes_key.encrypt(new_available as u64).into();
 
     let expected_counter: u64 = ct_extension.pending_balance_credit_counter.into();
 
@@ -92,7 +79,7 @@ pub async fn apply_pending_balance(
         &spl_token_2022::id(),
         &token_account,
         expected_counter,
-        &new_decryptable_legacy,
+        &new_decryptable,
         &authority.pubkey(),
         &[&authority.pubkey()],
     )?;

--- a/src/balances.rs
+++ b/src/balances.rs
@@ -1,0 +1,104 @@
+//! Read and decrypt the balances on a confidential token account.
+//!
+//! Shared by the examples and demo flows so the ciphertext decoding and lo/hi
+//! pending recombination live in exactly one place.
+
+use crate::types::*;
+use solana_client::rpc_client::RpcClient;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_zk_sdk::encryption::{
+    auth_encryption::{AeCiphertext, AeKey},
+    elgamal::{ElGamalCiphertext, ElGamalKeypair},
+};
+use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token_2022::{
+    extension::{
+        confidential_transfer::ConfidentialTransferAccount, BaseStateWithExtensions,
+        StateWithExtensions,
+    },
+    state::Account as TokenAccount,
+};
+
+/// The three balance buckets on a confidential account, all in base units.
+#[derive(Clone, Copy, Debug)]
+pub struct Balances {
+    /// Visible to everyone on chain.
+    pub public: u64,
+    /// ElGamal-encrypted, credited by deposits/transfers, needs `apply_pending`.
+    pub pending: u64,
+    /// Spendable confidential balance (decrypted via the cheap AES path).
+    pub available: u64,
+}
+
+impl Balances {
+    pub fn total(&self) -> u64 {
+        self.public + self.pending + self.available
+    }
+}
+
+/// Decode an on-chain POD ElGamal ciphertext.
+fn decode_ciphertext(field: &PodElGamalCiphertext, what: &str) -> CtResult<ElGamalCiphertext> {
+    (*field)
+        .try_into()
+        .map_err(|e| format!("decode {what}: {e:?}").into())
+}
+
+/// Fetch `owner`'s confidential account for `mint` and decrypt every balance.
+///
+/// Pending is recovered via ElGamal (lo/hi split, recombined); available via
+/// the AES decryptable balance. Encryption keys are derived from the owner's
+/// signature, so `owner` must be the account authority.
+pub fn read_balances(client: &RpcClient, owner: &dyn Signer, mint: &Pubkey) -> CtResult<Balances> {
+    let token_account =
+        get_associated_token_address_with_program_id(&owner.pubkey(), mint, &spl_token_2022::id());
+    let elgamal_keypair = ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes())?;
+    let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes())?;
+
+    let account_data = client.get_account(&token_account)?;
+    let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
+    let ext = account.get_extension::<ConfidentialTransferAccount>()?;
+
+    let public = account.base.amount;
+
+    let pending_lo = decode_ciphertext(&ext.pending_balance_lo, "pending_balance_lo")?
+        .decrypt_u32(elgamal_keypair.secret())
+        .ok_or("decrypt pending_balance_lo")?;
+    let pending_hi = decode_ciphertext(&ext.pending_balance_hi, "pending_balance_hi")?
+        .decrypt_u32(elgamal_keypair.secret())
+        .ok_or("decrypt pending_balance_hi")?;
+    let pending = pending_lo + (pending_hi << 16);
+
+    let decryptable: AeCiphertext = ext
+        .decryptable_available_balance
+        .try_into()
+        .map_err(|e| format!("decode decryptable_available_balance: {e:?}"))?;
+    let available = decryptable
+        .decrypt(&aes_key)
+        .ok_or("decrypt decryptable_available_balance")?;
+
+    Ok(Balances {
+        public,
+        pending,
+        available,
+    })
+}
+
+/// Decrypt the available balance via the (expensive) ElGamal path, for callers
+/// that want to confirm it matches the AES decryptable balance.
+pub fn read_available_elgamal(
+    client: &RpcClient,
+    owner: &dyn Signer,
+    mint: &Pubkey,
+) -> CtResult<u64> {
+    let token_account =
+        get_associated_token_address_with_program_id(&owner.pubkey(), mint, &spl_token_2022::id());
+    let elgamal_keypair = ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes())?;
+    let account_data = client.get_account(&token_account)?;
+    let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
+    let ext = account.get_extension::<ConfidentialTransferAccount>()?;
+    decode_ciphertext(&ext.available_balance, "available_balance")?
+        .decrypt_u32(elgamal_keypair.secret())
+        .ok_or_else(|| "decrypt available_balance (ElGamal)".into())
+}

--- a/src/batch_transfer.rs
+++ b/src/batch_transfer.rs
@@ -1,0 +1,584 @@
+//! Batched confidential transfers from a *single* sender.
+//!
+//! ## Why the sending side is serial
+//!
+//! Every confidential transfer debits the sender's `available_balance`, which
+//! lives on chain only as an opaque ElGamal ciphertext. Spending is a
+//! read-modify-write against that ciphertext: the equality proof binds to the
+//! *current* available-balance ciphertext, and the AES `decryptable_available_balance`
+//! is overwritten with a fresh running cleartext. Two transfers generated
+//! against the same starting ciphertext therefore cannot both land: whichever
+//! lands first mutates the ciphertext, and the second's equality proof no
+//! longer matches the value the token program recomputes. So N transfers from
+//! one sender are inherently ordered.
+//!
+//! ## What "batching" actually buys us
+//!
+//! The sender holds the secret, so the entire chain of intermediate states can
+//! be computed *offline* without a round trip per transfer. ElGamal ciphertexts
+//! subtract homomorphically, and the proof-generation crate exposes the new
+//! available-balance ciphertext it derives inside each proof (it is the
+//! `ciphertext` field of the equality proof context). We feed that ciphertext
+//! straight into the next transfer's proof:
+//!
+//! ```text
+//! C0 = on-chain available balance
+//! proof_i = transfer_split_proof_data(C_i, encrypt(running_i), amount_i, ...)
+//! C_{i+1} = proof_i.equality_proof_data.context.ciphertext   // C_i ⊖ Enc(amount_i)
+//! running_{i+1} = running_i - amount_i
+//! ```
+//!
+//! [`prepare_legs`] runs that loop once, decrypting the balance a single time.
+//! Two execution strategies then ship the prepared legs:
+//!
+//! * [`batch_transfer_atomic`] (option 1): pre-verify every leg's proofs into
+//!   context state accounts, then submit ONE v0 transaction containing all N
+//!   `Transfer` instructions. Same-tx instruction order makes the chained
+//!   proofs validate deterministically. An Address Lookup Table compresses the
+//!   account list so several legs fit, and a compute-budget bump clears the CU
+//!   ceiling. Bounded by tx size / CU; this is the real "batch".
+//!
+//! * [`batch_transfer_pipelined`] (option 2): same offline proof generation,
+//!   but submit each leg as its own confirmed transaction in sequence. No
+//!   size/CU ceiling and unbounded fan-out, at the cost of one confirmation per
+//!   leg. Legs must land in order or a later leg's proof goes stale.
+
+use crate::transfer::{send_tx, ZK_PROOF_PROGRAM_ID};
+use crate::types::*;
+use solana_address::Address;
+use solana_address_lookup_table_interface::instruction::{
+    create_lookup_table, extend_lookup_table,
+};
+use solana_client::rpc_client::RpcClient;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::Instruction;
+use solana_keypair::Keypair;
+use solana_message::{v0, AddressLookupTableAccount, VersionedMessage};
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_system_interface::instruction as system_instruction;
+use solana_transaction::versioned::VersionedTransaction;
+use solana_zk_elgamal_proof_interface::{
+    instruction::{close_context_state, ContextStateInfo, ProofInstruction},
+    proof_data::{
+        BatchedGroupedCiphertext3HandlesValidityProofContext, BatchedRangeProofContext,
+        CiphertextCommitmentEqualityProofContext, ZkProofData,
+    },
+    state::ProofContextState,
+};
+use solana_zk_sdk::encryption::{
+    auth_encryption::{AeCiphertext, AeKey},
+    elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+};
+use solana_zk_sdk_pod::encryption::{
+    auth_encryption::PodAeCiphertext, elgamal::PodElGamalPubkey,
+};
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token_2022::{
+    extension::{
+        confidential_transfer::{
+            instruction::{
+                inner_transfer, BatchedGroupedCiphertext3HandlesValidityProofData,
+                BatchedRangeProofU128Data, CiphertextCommitmentEqualityProofData,
+            },
+            ConfidentialTransferAccount, ConfidentialTransferMint,
+        },
+        BaseStateWithExtensions, StateWithExtensions,
+    },
+    state::{Account as TokenAccount, Mint},
+};
+use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
+use spl_token_confidential_transfer_proof_generation::transfer::{
+    transfer_split_proof_data, TransferProofData,
+};
+use std::mem::size_of;
+use std::time::Duration;
+
+/// One destination of a batched transfer.
+#[derive(Clone, Copy, Debug)]
+pub struct TransferLeg {
+    pub recipient: Pubkey,
+    pub amount: u64,
+}
+
+/// A leg with its proofs generated against the predicted chained sender state.
+struct PreparedLeg {
+    recipient_token_account: Pubkey,
+    proof: TransferProofData,
+    new_decryptable: PodAeCiphertext,
+}
+
+/// The three proof context accounts staged on chain for one leg.
+struct StagedLeg {
+    equality_account: Pubkey,
+    validity_account: Pubkey,
+    range_account: Pubkey,
+}
+
+/// Read the mint's optional auditor ElGamal pubkey.
+fn fetch_auditor_pubkey(client: &RpcClient, mint: &Pubkey) -> CtResult<Option<ElGamalPubkey>> {
+    let mint_acc_data = client.get_account(mint)?;
+    let mint_acc = StateWithExtensions::<Mint>::unpack(&mint_acc_data.data)?;
+    let mint_ext = mint_acc.get_extension::<ConfidentialTransferMint>()?;
+    Option::<PodElGamalPubkey>::from(mint_ext.auditor_elgamal_pubkey)
+        .map(|pod| {
+            ElGamalPubkey::try_from(pod)
+                .map_err(|e| format!("auditor ElGamal pubkey: {e:?}").into())
+        })
+        .transpose()
+}
+
+/// Read a configured account's ElGamal pubkey.
+fn fetch_elgamal_pubkey(client: &RpcClient, token_account: &Pubkey) -> CtResult<ElGamalPubkey> {
+    let acc_data = client.get_account(token_account)?;
+    let acc = StateWithExtensions::<TokenAccount>::unpack(&acc_data.data)?;
+    let ext = acc.get_extension::<ConfidentialTransferAccount>()?;
+    ext.elgamal_pubkey
+        .try_into()
+        .map_err(|e| format!("recipient ElGamal pubkey: {e:?}").into())
+}
+
+/// Walk the legs once, generating each transfer's proofs against the sender
+/// state predicted by the previous legs. Decrypts the available balance exactly
+/// once; everything after is offline ciphertext arithmetic.
+fn prepare_legs(
+    client: &RpcClient,
+    sender_token_account: &Pubkey,
+    sender_elgamal: &ElGamalKeypair,
+    sender_aes: &AeKey,
+    mint: &Pubkey,
+    legs: &[TransferLeg],
+    auditor: Option<&ElGamalPubkey>,
+) -> CtResult<Vec<PreparedLeg>> {
+    let sender_acc_data = client.get_account(sender_token_account)?;
+    let sender_acc = StateWithExtensions::<TokenAccount>::unpack(&sender_acc_data.data)?;
+    let sender_ext = sender_acc.get_extension::<ConfidentialTransferAccount>()?;
+
+    // Starting available-balance ciphertext (C0) and its cleartext value.
+    let mut current_ct: ElGamalCiphertext = sender_ext
+        .available_balance
+        .try_into()
+        .map_err(|e| format!("sender available balance: {e:?}"))?;
+    let current_decryptable: AeCiphertext = sender_ext
+        .decryptable_available_balance
+        .try_into()
+        .map_err(|e| format!("sender decryptable balance: {e:?}"))?;
+    let mut running = current_decryptable
+        .decrypt(sender_aes)
+        .ok_or("decrypt sender available balance")?;
+
+    let total: u64 = legs.iter().map(|l| l.amount).sum();
+    if running < total {
+        return Err(format!(
+            "Insufficient confidential balance: have {running}, need {total} across {} legs",
+            legs.len()
+        )
+        .into());
+    }
+
+    let mut prepared = Vec::with_capacity(legs.len());
+    for leg in legs {
+        let recipient_token_account = get_associated_token_address_with_program_id(
+            &leg.recipient,
+            mint,
+            &spl_token_2022::id(),
+        );
+        let recipient_elgamal = fetch_elgamal_pubkey(client, &recipient_token_account)?;
+
+        // The proof generator only reads the cleartext out of this AES
+        // ciphertext, so a fresh encryption of `running` stands in for the
+        // (randomized) on-chain ciphertext the previous leg would have written.
+        let decryptable_in = sender_aes.encrypt(running);
+
+        let proof = transfer_split_proof_data(
+            &current_ct,
+            &decryptable_in,
+            leg.amount,
+            sender_elgamal,
+            sender_aes,
+            &recipient_elgamal,
+            auditor,
+        )
+        .map_err(|e| format!("transfer_split_proof_data: {e}"))?;
+
+        running = running
+            .checked_sub(leg.amount)
+            .ok_or("leg amount exceeds running balance")?;
+        let new_decryptable: PodAeCiphertext = sender_aes.encrypt(running).into();
+
+        // Chain forward: the equality proof context holds C_i ⊖ Enc(amount_i),
+        // exactly the available-balance ciphertext the chain will leave behind.
+        let next_ct = proof.equality_proof_data.context_data().ciphertext;
+        current_ct = next_ct
+            .try_into()
+            .map_err(|e| format!("chained available balance: {e:?}"))?;
+
+        prepared.push(PreparedLeg {
+            recipient_token_account,
+            proof,
+            new_decryptable,
+        });
+    }
+
+    Ok(prepared)
+}
+
+/// Pre-verify a single leg's three proofs into context state accounts,
+/// mirroring the single-transfer flow: one tx creates all three accounts and
+/// verifies the validity proof, the oversized range proof verifies alone (it
+/// only fits under the 1232-byte limit with payer as the context-state
+/// authority), and the equality proof verifies in a third tx since the
+/// transfer it would otherwise ride with happens later.
+fn stage_leg(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    leg: &PreparedLeg,
+    sigs: &mut Vec<Signature>,
+) -> CtResult<StagedLeg> {
+    let equality_account = Keypair::new();
+    let validity_account = Keypair::new();
+    let range_account = Keypair::new();
+
+    let equality_size = size_of::<ProofContextState<CiphertextCommitmentEqualityProofContext>>();
+    let validity_size =
+        size_of::<ProofContextState<BatchedGroupedCiphertext3HandlesValidityProofContext>>();
+    let range_size = size_of::<ProofContextState<BatchedRangeProofContext>>();
+
+    let equality_rent = client.get_minimum_balance_for_rent_exemption(equality_size)?;
+    let validity_rent = client.get_minimum_balance_for_rent_exemption(validity_size)?;
+    let range_rent = client.get_minimum_balance_for_rent_exemption(range_size)?;
+
+    let equality_create_ix = system_instruction::create_account(
+        &payer.pubkey(),
+        &equality_account.pubkey(),
+        equality_rent,
+        equality_size as u64,
+        &ZK_PROOF_PROGRAM_ID,
+    );
+    let validity_create_ix = system_instruction::create_account(
+        &payer.pubkey(),
+        &validity_account.pubkey(),
+        validity_rent,
+        validity_size as u64,
+        &ZK_PROOF_PROGRAM_ID,
+    );
+    let range_create_ix = system_instruction::create_account(
+        &payer.pubkey(),
+        &range_account.pubkey(),
+        range_rent,
+        range_size as u64,
+        &ZK_PROOF_PROGRAM_ID,
+    );
+
+    let payer_addr: Address = payer.pubkey().to_bytes().into();
+    let equality_verify_ix = ProofInstruction::VerifyCiphertextCommitmentEquality
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &Address::from(equality_account.pubkey().to_bytes()),
+                context_state_authority: &payer_addr,
+            }),
+            &leg.proof.equality_proof_data,
+        );
+    let validity_verify_ix = ProofInstruction::VerifyBatchedGroupedCiphertext3HandlesValidity
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &Address::from(validity_account.pubkey().to_bytes()),
+                context_state_authority: &payer_addr,
+            }),
+            &leg
+                .proof
+                .ciphertext_validity_proof_data_with_ciphertext
+                .proof_data,
+        );
+    let range_verify_ix = ProofInstruction::VerifyBatchedRangeProofU128.encode_verify_proof(
+        Some(ContextStateInfo {
+            context_state_account: &Address::from(range_account.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
+        }),
+        &leg.proof.range_proof_data,
+    );
+
+    // Tx 1: create all 3 proof accounts + verify the validity proof.
+    sigs.push(send_tx(
+        client,
+        &[
+            equality_create_ix,
+            validity_create_ix,
+            range_create_ix,
+            validity_verify_ix,
+        ],
+        &[payer, &equality_account, &validity_account, &range_account],
+        &payer.pubkey(),
+    )?);
+
+    // Tx 2: verify the range proof on its own (~1206 bytes, just under the
+    // legacy tx size limit).
+    sigs.push(send_tx(client, &[range_verify_ix], &[payer], &payer.pubkey())?);
+
+    // Tx 3: verify the equality proof. In the single-transfer flow this rides
+    // with the transfer ix, but here the transfers land later (potentially all
+    // in one atomic tx), so it gets its own tx.
+    sigs.push(send_tx(
+        client,
+        &[equality_verify_ix],
+        &[payer],
+        &payer.pubkey(),
+    )?);
+
+    Ok(StagedLeg {
+        equality_account: equality_account.pubkey(),
+        validity_account: validity_account.pubkey(),
+        range_account: range_account.pubkey(),
+    })
+}
+
+/// Build the `Transfer` instruction for a leg referencing its staged proofs.
+fn transfer_ix_for(
+    sender_token_account: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    leg: &PreparedLeg,
+    staged: &StagedLeg,
+) -> CtResult<Instruction> {
+    let equality_loc: ProofLocation<CiphertextCommitmentEqualityProofData> =
+        ProofLocation::ContextStateAccount(&staged.equality_account);
+    let validity_loc: ProofLocation<BatchedGroupedCiphertext3HandlesValidityProofData> =
+        ProofLocation::ContextStateAccount(&staged.validity_account);
+    let range_loc: ProofLocation<BatchedRangeProofU128Data> =
+        ProofLocation::ContextStateAccount(&staged.range_account);
+
+    inner_transfer(
+        &spl_token_2022::id(),
+        sender_token_account,
+        mint,
+        &leg.recipient_token_account,
+        &leg.new_decryptable,
+        &leg.proof.ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo,
+        &leg.proof.ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi,
+        authority,
+        &[],
+        equality_loc,
+        validity_loc,
+        range_loc,
+    )
+    .map_err(|e| format!("inner_transfer: {e}").into())
+}
+
+/// Close a leg's proof context accounts. Payer is the context-state authority
+/// on all of them, and reclaims the rent.
+fn close_leg_ixs(payer: &Pubkey, staged: &StagedLeg) -> Vec<Instruction> {
+    let payer_addr = Address::from(payer.to_bytes());
+    let close_ctx = |ctx: &Pubkey| {
+        close_context_state(
+            ContextStateInfo {
+                context_state_account: &Address::from(ctx.to_bytes()),
+                context_state_authority: &payer_addr,
+            },
+            &payer_addr,
+        )
+    };
+    vec![
+        close_ctx(&staged.equality_account),
+        close_ctx(&staged.validity_account),
+        close_ctx(&staged.range_account),
+    ]
+}
+
+// ----------------------------------------------------------------------------
+// Option 2: pipelined (one confirmed transaction per leg)
+// ----------------------------------------------------------------------------
+
+/// Submit `legs` transfers from `sender` as a pipeline of confirmed
+/// transactions: proofs are all generated offline up front, then each leg is
+/// staged, transferred, and closed in order. No transaction-size or compute
+/// ceiling, but one round of confirmation per leg.
+pub async fn batch_transfer_pipelined(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    sender: &Keypair,
+    mint: &Pubkey,
+    legs: &[TransferLeg],
+) -> MultiSigResult {
+    let sender_token_account =
+        get_associated_token_address_with_program_id(&sender.pubkey(), mint, &spl_token_2022::id());
+    let sender_elgamal = ElGamalKeypair::new_from_signer(sender, &sender_token_account.to_bytes())?;
+    let sender_aes = AeKey::new_from_signer(sender, &sender_token_account.to_bytes())?;
+    let auditor = fetch_auditor_pubkey(client, mint)?;
+
+    let prepared = prepare_legs(
+        client,
+        &sender_token_account,
+        &sender_elgamal,
+        &sender_aes,
+        mint,
+        legs,
+        auditor.as_ref(),
+    )?;
+
+    let mut sigs = Vec::new();
+    for (i, leg) in prepared.iter().enumerate() {
+        let staged = stage_leg(client, payer, leg, &mut sigs)?;
+
+        let transfer_ix =
+            transfer_ix_for(&sender_token_account, mint, &sender.pubkey(), leg, &staged)?;
+        let mut ixs = vec![transfer_ix];
+        ixs.extend(close_leg_ixs(&payer.pubkey(), &staged));
+
+        let sig = send_tx(client, &ixs, &[payer, sender], &payer.pubkey())?;
+        sigs.push(sig);
+        println!(
+            "  leg {}/{}: {} -> {} ({} lamports of token) [{}]",
+            i + 1,
+            prepared.len(),
+            sender.pubkey(),
+            leg.recipient_token_account,
+            legs[i].amount,
+            sig
+        );
+    }
+
+    println!(
+        "✅ Pipelined batch transfer complete: {} legs in {} transactions",
+        prepared.len(),
+        sigs.len()
+    );
+    Ok(sigs)
+}
+
+// ----------------------------------------------------------------------------
+// Option 1: atomic (all legs in one v0 transaction via an Address Lookup Table)
+// ----------------------------------------------------------------------------
+
+/// Submit all `legs` transfers from `sender` in a single atomic transaction.
+///
+/// Proofs are pre-verified into context state accounts (parallelizable, but
+/// done sequentially here for clarity), an Address Lookup Table is created to
+/// compress the account list, and one v0 transaction carries a compute-budget
+/// bump plus every `Transfer` instruction. Because the instructions execute in
+/// order within the transaction, the offline-chained proofs validate against
+/// the exact intermediate ciphertexts each leg expects.
+///
+/// Bounded by transaction size and compute units: very large batches should
+/// fall back to [`batch_transfer_pipelined`].
+pub async fn batch_transfer_atomic(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    sender: &Keypair,
+    mint: &Pubkey,
+    legs: &[TransferLeg],
+    compute_unit_limit: u32,
+) -> MultiSigResult {
+    let sender_token_account =
+        get_associated_token_address_with_program_id(&sender.pubkey(), mint, &spl_token_2022::id());
+    let sender_elgamal = ElGamalKeypair::new_from_signer(sender, &sender_token_account.to_bytes())?;
+    let sender_aes = AeKey::new_from_signer(sender, &sender_token_account.to_bytes())?;
+    let auditor = fetch_auditor_pubkey(client, mint)?;
+
+    let prepared = prepare_legs(
+        client,
+        &sender_token_account,
+        &sender_elgamal,
+        &sender_aes,
+        mint,
+        legs,
+        auditor.as_ref(),
+    )?;
+
+    // Stage every leg's proofs. These touch only fresh accounts, so they don't
+    // conflict with each other and could be parallelized.
+    let mut sigs = Vec::new();
+    let mut staged_legs = Vec::with_capacity(prepared.len());
+    for (i, leg) in prepared.iter().enumerate() {
+        println!("  staging proofs for leg {}/{}", i + 1, prepared.len());
+        let staged = stage_leg(client, payer, leg, &mut sigs)?;
+        staged_legs.push(staged);
+    }
+
+    // Build an Address Lookup Table holding the accounts the transfers
+    // reference, so the v0 message can address them by 1-byte index.
+    // `create_lookup_table` derives the LUT address from a slot that must be
+    // in the SlotHashes sysvar as seen at execution; a confirmed-commitment
+    // slot can be too fresh, so anchor to the finalized slot.
+    let recent_slot =
+        client.get_slot_with_commitment(solana_commitment_config::CommitmentConfig::finalized())?;
+    let (create_ix, lut_address) =
+        create_lookup_table(payer.pubkey(), payer.pubkey(), recent_slot);
+
+    let mut lut_addresses: Vec<Pubkey> =
+        vec![spl_token_2022::id(), *mint, sender_token_account];
+    for (leg, staged) in prepared.iter().zip(&staged_legs) {
+        lut_addresses.push(leg.recipient_token_account);
+        lut_addresses.push(staged.equality_account);
+        lut_addresses.push(staged.validity_account);
+        lut_addresses.push(staged.range_account);
+    }
+    let extend_ix = extend_lookup_table(
+        lut_address,
+        payer.pubkey(),
+        Some(payer.pubkey()),
+        lut_addresses.clone(),
+    );
+
+    sigs.push(send_tx(client, &[create_ix], &[payer], &payer.pubkey())?);
+    sigs.push(send_tx(client, &[extend_ix], &[payer], &payer.pubkey())?);
+    println!("  created + extended lookup table {lut_address}");
+
+    // A lookup table is only usable in a transaction processed in a later slot
+    // than the one its last extension landed in. Wait for the slot to advance.
+    wait_for_slot_advance(client).await?;
+
+    // Assemble the atomic transaction: compute budget + one Transfer per leg.
+    let mut ixs = vec![ComputeBudgetInstruction::set_compute_unit_limit(
+        compute_unit_limit,
+    )];
+    for (leg, staged) in prepared.iter().zip(&staged_legs) {
+        ixs.push(transfer_ix_for(
+            &sender_token_account,
+            mint,
+            &sender.pubkey(),
+            leg,
+            staged,
+        )?);
+    }
+
+    let alt = AddressLookupTableAccount {
+        key: lut_address,
+        addresses: lut_addresses,
+    };
+    let blockhash = client.get_latest_blockhash()?;
+    let message = v0::Message::try_compile(&payer.pubkey(), &ixs, &[alt], blockhash)
+        .map_err(|e| format!("compile v0 message: {e}"))?;
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer, sender])
+        .map_err(|e| format!("sign v0 transaction: {e}"))?;
+
+    let atomic_sig = client.send_and_confirm_transaction(&tx)?;
+    sigs.push(atomic_sig);
+    println!(
+        "✅ Atomic batch transfer complete: {} legs in 1 transaction [{}]",
+        prepared.len(),
+        atomic_sig
+    );
+
+    // Reclaim rent: close every leg's proof context accounts. The transfers
+    // already consumed the verified proofs.
+    for staged in &staged_legs {
+        let ixs = close_leg_ixs(&payer.pubkey(), staged);
+        sigs.push(send_tx(client, &ixs, &[payer], &payer.pubkey())?);
+    }
+
+    Ok(sigs)
+}
+
+/// Poll until the cluster slot advances past the current one, so a freshly
+/// extended lookup table becomes usable.
+async fn wait_for_slot_advance(client: &RpcClient) -> CtResult<()> {
+    let start = client.get_slot()?;
+    for _ in 0..40 {
+        if client.get_slot()? > start {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+    Err("lookup table did not warm up: slot never advanced".into())
+}

--- a/src/bin/demo-server.rs
+++ b/src/bin/demo-server.rs
@@ -57,16 +57,13 @@ use spl_token_2022::{
         BaseStateWithExtensions, ExtensionType, StateWithExtensions,
     },
     instruction::{initialize_mint as initialize_mint_base, mint_to},
-    solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey as PodElGamalPubkeyLegacy,
     state::{Account as TokenAccount, Mint},
 };
 use solana_zk_sdk::encryption::{
     auth_encryption::{AeCiphertext, AeKey},
     elgamal::{ElGamalCiphertext, ElGamalKeypair},
 };
-use solana_zk_sdk_pod::encryption::elgamal::{
-    PodElGamalCiphertext as PodElGamalCiphertextV6, PodElGamalPubkey as PodElGamalPubkeyV6,
-};
+use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
@@ -514,7 +511,10 @@ async fn transfer_handler(
             }
         };
 
-        if let Some(transfer_sig) = sigs.get(3) {
+        // The 3-tx flow puts the actual `inner_transfer` ix in the last tx
+        // (alongside eq_verify + 3 closes), so the transfer signature is the
+        // last one we got back from `transfer_confidential_with_progress`.
+        if let Some(transfer_sig) = sigs.last() {
             log_event(&s, "transfer", amount_ui, transfer_sig).await;
         }
 
@@ -649,11 +649,8 @@ fn verify_mint_matches(s: &AppState) -> Result<()> {
         .get_extension::<ConfidentialTransferMint>()
         .map_err(|e| anyhow!("mint missing ConfidentialTransferMint extension: {e}"))?;
 
-    let expected_v6: PodElGamalPubkeyV6 = (*s.auditor_elgamal.pubkey()).into();
-    // Wire format for the on-chain account is the 4.0 PodElGamalPubkey, but
-    // the bytes are identical; cast through.
-    let expected = PodElGamalPubkeyLegacy::from(expected_v6.0);
-    let actual: Option<PodElGamalPubkeyLegacy> = Option::from(ct.auditor_elgamal_pubkey);
+    let expected: PodElGamalPubkey = (*s.auditor_elgamal.pubkey()).into();
+    let actual: Option<PodElGamalPubkey> = Option::from(ct.auditor_elgamal_pubkey);
     match actual {
         Some(actual) if actual == expected => Ok(()),
         Some(_) => Err(anyhow!(
@@ -671,9 +668,7 @@ async fn create_confidential_mint(s: &AppState) -> Result<Signature> {
         ExtensionType::ConfidentialTransferMint,
     ])?;
     let rent = s.rpc.get_minimum_balance_for_rent_exemption(space)?;
-    // 6.0.1 → 4.0 PodElGamalPubkey via bytes (identical wire format).
-    let auditor_pod_v6: PodElGamalPubkeyV6 = (*s.auditor_elgamal.pubkey()).into();
-    let auditor_pod = PodElGamalPubkeyLegacy::from(auditor_pod_v6.0);
+    let auditor_pod: PodElGamalPubkey = (*s.auditor_elgamal.pubkey()).into();
 
     let create_ix = system_instruction::create_account(
         &s.keys.payer.pubkey(),
@@ -879,30 +874,16 @@ fn read_account_view(s: &AppState, owner: &Keypair) -> Result<AccountView> {
             let aes = AeKey::new_from_signer(owner, &token_account.to_bytes())
                 .map_err(|e| anyhow!("derive AES key: {e}"))?;
 
-            // 4.0 POD ciphertexts on chain → 6.0.1 PODs via byte cast → 6.0.1
-            // ElGamalCiphertext / AeCiphertext for the actual decryption.
-            let pending_lo_pod = PodElGamalCiphertextV6(
-                bytemuck::bytes_of(&ext.pending_balance_lo)
-                    .try_into()
-                    .map_err(|_| anyhow!("pending_balance_lo size"))?,
-            );
-            let pending_hi_pod = PodElGamalCiphertextV6(
-                bytemuck::bytes_of(&ext.pending_balance_hi)
-                    .try_into()
-                    .map_err(|_| anyhow!("pending_balance_hi size"))?,
-            );
-            let avail_pod = PodElGamalCiphertextV6(
-                bytemuck::bytes_of(&ext.available_balance)
-                    .try_into()
-                    .map_err(|_| anyhow!("available_balance size"))?,
-            );
-            let pending_lo: ElGamalCiphertext = pending_lo_pod
+            let pending_lo: ElGamalCiphertext = ext
+                .pending_balance_lo
                 .try_into()
                 .map_err(|e| anyhow!("decode pending_lo: {e:?}"))?;
-            let pending_hi: ElGamalCiphertext = pending_hi_pod
+            let pending_hi: ElGamalCiphertext = ext
+                .pending_balance_hi
                 .try_into()
                 .map_err(|e| anyhow!("decode pending_hi: {e:?}"))?;
-            let avail_ct: ElGamalCiphertext = avail_pod
+            let avail_ct: ElGamalCiphertext = ext
+                .available_balance
                 .try_into()
                 .map_err(|e| anyhow!("decode available_balance: {e:?}"))?;
 
@@ -910,11 +891,10 @@ fn read_account_view(s: &AppState, owner: &Keypair) -> Result<AccountView> {
             let pending_hi_v = pending_hi.decrypt_u32(elgamal.secret()).unwrap_or(0) as u64;
             let pending_total = pending_lo_v + (pending_hi_v << 16);
 
-            let avail_aes_bytes: [u8; 36] = bytemuck::bytes_of(&ext.decryptable_available_balance)
+            let avail_aes: AeCiphertext = ext
+                .decryptable_available_balance
                 .try_into()
-                .map_err(|_| anyhow!("decryptable_available_balance size"))?;
-            let avail_aes = AeCiphertext::from_bytes(&avail_aes_bytes)
-                .ok_or_else(|| anyhow!("decode AeCiphertext"))?;
+                .map_err(|e| anyhow!("decode AeCiphertext: {e:?}"))?;
             let avail_v = aes.decrypt(&avail_aes).unwrap_or(0);
 
             (

--- a/src/bin/demo-server.rs
+++ b/src/bin/demo-server.rs
@@ -38,11 +38,11 @@ use tokio_stream::wrappers::BroadcastStream;
 use serde::{Deserialize, Serialize};
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signature, Signer},
-    transaction::Transaction,
-};
+use solana_pubkey::Pubkey;
+use solana_keypair::Keypair;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use solana_system_interface::instruction as system_instruction;
 use spl_associated_token_account::{
     get_associated_token_address_with_program_id,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -8,11 +8,10 @@
 use crate::types::*;
 use solana_address::Address;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
+use solana_pubkey::Pubkey;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use solana_system_interface::instruction as system_instruction;
 use solana_zk_elgamal_proof_interface::{
     instruction::{ContextStateInfo, ProofInstruction},
@@ -36,7 +35,7 @@ use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation
 use std::mem::size_of;
 
 const ZK_PROOF_PROGRAM_ID: Pubkey =
-    solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
+    solana_pubkey::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
 
 pub async fn configure_account_for_confidential_transfers(
     client: &RpcClient,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,9 +1,8 @@
-//! Configure a token account for confidential transfers (bypass mode).
+//! Configure a token account for confidential transfers.
 //!
-//! Generates the PubkeyValidity proof using `solana-zk-sdk = 6.0.1`
-//! (the format the deployed devnet program expects), pre-verifies it into a
-//! context state account, and references the account in
-//! `spl-token-2022 = 10.0.0`'s `configure_account` via
+//! Generates the PubkeyValidity proof with solana-zk-sdk 6.0.1, pre-verifies
+//! it into a context state account, and references that account in
+//! spl-token-2022 11.0.0's `configure_account` via
 //! `ProofLocation::ContextStateAccount`.
 
 use crate::types::*;
@@ -24,16 +23,14 @@ use solana_zk_sdk::{
     encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
     zk_elgamal_proof_program::pubkey_validity::build_pubkey_validity_proof_data,
 };
+use solana_zk_sdk_pod::encryption::auth_encryption::PodAeCiphertext;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
     extension::{
-        confidential_transfer::instruction::{
-            configure_account, PubkeyValidityProofData as PubkeyValidityProofDataLegacy,
-        },
+        confidential_transfer::instruction::{configure_account, PubkeyValidityProofData},
         ExtensionType,
     },
     instruction::reallocate,
-    solana_zk_sdk::encryption::pod::auth_encryption::PodAeCiphertext as PodAeCiphertextLegacy,
 };
 use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
 use std::mem::size_of;
@@ -61,10 +58,7 @@ pub async fn configure_account_for_confidential_transfers(
 
     let max_pending_balance_credit_counter: u64 = 65536;
 
-    // 6.0.1 AeCiphertext → 4.0 PodAeCiphertext via byte cast. Wire format is
-    // identical (36 bytes); we just have two Rust types for it.
-    let decryptable_balance_v6 = aes_key.encrypt(0u64);
-    let decryptable_balance_legacy = PodAeCiphertextLegacy::from(decryptable_balance_v6.to_bytes());
+    let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0u64).into();
 
     let proof_data = build_pubkey_validity_proof_data(&elgamal_keypair)
         .map_err(|e| format!("generate pubkey validity proof: {e}"))?;
@@ -100,13 +94,13 @@ pub async fn configure_account_for_confidential_transfers(
         &proof_data,
     );
 
-    let proof_location: ProofLocation<PubkeyValidityProofDataLegacy> =
+    let proof_location: ProofLocation<PubkeyValidityProofData> =
         ProofLocation::ContextStateAccount(&proof_account.pubkey());
     let configure_ixs = configure_account(
         &spl_token_2022::id(),
         &token_account,
         mint,
-        &decryptable_balance_legacy,
+        &decryptable_balance,
         max_pending_balance_credit_counter,
         &authority.pubkey(),
         &[],

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -43,6 +43,19 @@ pub async fn configure_account_for_confidential_transfers(
     authority: &dyn Signer,
     mint: &Pubkey,
 ) -> SigResult {
+    configure_account_with_extensions(client, payer, authority, mint, &[]).await
+}
+
+/// Like [`configure_account_for_confidential_transfers`], but reallocates the
+/// token account for `extra_extensions` too. A mint with confidential fees
+/// needs its accounts to carry `ExtensionType::ConfidentialTransferFeeAmount`.
+pub async fn configure_account_with_extensions(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    authority: &dyn Signer,
+    mint: &Pubkey,
+    extra_extensions: &[ExtensionType],
+) -> SigResult {
     let token_account = get_associated_token_address_with_program_id(
         &authority.pubkey(),
         mint,
@@ -66,13 +79,15 @@ pub async fn configure_account_for_confidential_transfers(
     let context_state_size = size_of::<ProofContextState<PubkeyValidityProofContext>>();
     let context_state_rent = client.get_minimum_balance_for_rent_exemption(context_state_size)?;
 
+    let mut extensions = vec![ExtensionType::ConfidentialTransferAccount];
+    extensions.extend_from_slice(extra_extensions);
     let realloc_ix = reallocate(
         &spl_token_2022::id(),
         &token_account,
         &payer.pubkey(),
         &authority.pubkey(),
         &[&authority.pubkey()],
-        &[ExtensionType::ConfidentialTransferAccount],
+        &extensions,
     )?;
 
     let create_proof_account_ix = system_instruction::create_account(

--- a/src/deposit.rs
+++ b/src/deposit.rs
@@ -2,10 +2,8 @@
 
 use crate::types::*;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    signature::Signer,
-    transaction::Transaction,
-};
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::extension::confidential_transfer::instruction::deposit;
 
@@ -24,7 +22,7 @@ pub async fn deposit_to_confidential(
     client: &RpcClient,
     payer: &dyn Signer,
     authority: &dyn Signer,
-    mint: &solana_sdk::pubkey::Pubkey,
+    mint: &solana_pubkey::Pubkey,
     amount: u64,
     decimals: u8,
 ) -> SigResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod apply_pending;
 pub mod withdraw;
 pub mod transfer;
 pub mod batch_transfer;
+pub mod balances;
+pub mod setup;
 
 // Re-export common types
 pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod deposit;
 pub mod apply_pending;
 pub mod withdraw;
 pub mod transfer;
+pub mod batch_transfer;
 
 // Re-export common types
 pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod deposit;
 pub mod apply_pending;
 pub mod withdraw;
 pub mod transfer;
+pub mod transfer_with_fee;
 pub mod batch_transfer;
 pub mod balances;
 pub mod setup;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,7 +2,9 @@
 //! environment, create a confidential-transfer mint, and create + configure a
 //! token account for confidential transfers.
 
-use crate::configure::configure_account_for_confidential_transfers;
+use crate::configure::{
+    configure_account_for_confidential_transfers, configure_account_with_extensions,
+};
 use crate::types::*;
 use solana_client::rpc_client::RpcClient;
 use solana_keypair::Keypair;
@@ -14,8 +16,14 @@ use solana_zk_sdk::encryption::elgamal::ElGamalKeypair;
 use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
 use spl_associated_token_account::instruction::create_associated_token_account;
 use spl_token_2022::{
-    extension::{confidential_transfer::instruction::initialize_mint, ExtensionType},
-    instruction::initialize_mint as initialize_mint_base,
+    extension::{
+        confidential_transfer::instruction::initialize_mint,
+        confidential_transfer_fee::instruction::initialize_confidential_transfer_fee_config,
+        transfer_fee::instruction::initialize_transfer_fee_config, ExtensionType,
+    },
+    instruction::{
+        initialize_mint as initialize_mint_base, initialize_permanent_delegate,
+    },
     state::Mint,
 };
 
@@ -79,6 +87,100 @@ pub fn create_confidential_mint(
     Ok(mint)
 }
 
+/// Create a Token-2022 mint with confidential transfers, confidential
+/// transfer fees, and a permanent delegate:
+///
+/// * `TransferFeeConfig` — every transfer withholds `fee_basis_points` of the
+///   amount, capped at `maximum_fee`, on the recipient account.
+/// * `ConfidentialTransferFeeConfig` — the withheld amount on a confidential
+///   transfer is encrypted under `withheld_authority_elgamal_pubkey`, so only
+///   that key's holder can decrypt (and later withdraw) accumulated fees.
+/// * `PermanentDelegate` — `permanent_delegate` can transfer or burn from any
+///   token account of this mint, no owner signature needed.
+///
+/// `payer` is the mint authority, fee-config authority, and withdraw-withheld
+/// authority.
+pub fn create_confidential_fee_mint(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    decimals: u8,
+    fee_basis_points: u16,
+    maximum_fee: u64,
+    withheld_authority_elgamal_pubkey: &PodElGamalPubkey,
+    permanent_delegate: &Pubkey,
+) -> CtResult<Keypair> {
+    let mint = Keypair::new();
+    let space = ExtensionType::try_calculate_account_len::<Mint>(&[
+        ExtensionType::ConfidentialTransferMint,
+        ExtensionType::ConfidentialTransferFeeConfig,
+        ExtensionType::TransferFeeConfig,
+        ExtensionType::PermanentDelegate,
+    ])?;
+    let rent = client.get_minimum_balance_for_rent_exemption(space)?;
+
+    let auditor_elgamal = ElGamalKeypair::new_rand();
+    let auditor_pubkey_pod: PodElGamalPubkey = (*auditor_elgamal.pubkey()).into();
+    let payer_pubkey = payer.pubkey();
+
+    let create_account_ix = system_instruction::create_account(
+        &payer_pubkey,
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &spl_token_2022::id(),
+    );
+    let init_ct_ix = initialize_mint(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        None,
+        true,
+        Some(auditor_pubkey_pod),
+    )?;
+    let init_ct_fee_ix = initialize_confidential_transfer_fee_config(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        Some(payer_pubkey),
+        withheld_authority_elgamal_pubkey,
+    )?;
+    let init_fee_ix = initialize_transfer_fee_config(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        Some(&payer_pubkey),
+        Some(&payer_pubkey),
+        fee_basis_points,
+        maximum_fee,
+    )?;
+    let init_delegate_ix = initialize_permanent_delegate(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        permanent_delegate,
+    )?;
+    let init_mint_ix = initialize_mint_base(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        &payer.pubkey(),
+        None,
+        decimals,
+    )?;
+
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            create_account_ix,
+            init_ct_ix,
+            init_ct_fee_ix,
+            init_fee_ix,
+            init_delegate_ix,
+            init_mint_ix,
+        ],
+        Some(&payer.pubkey()),
+        &[payer, &mint],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+    Ok(mint)
+}
+
 /// Create `owner`'s associated token account for `mint` and configure it for
 /// confidential transfers.
 pub async fn create_and_configure_account(
@@ -103,5 +205,40 @@ pub async fn create_and_configure_account(
     client.send_and_confirm_transaction(&tx)?;
 
     configure_account_for_confidential_transfers(client, payer, owner, mint).await?;
+    Ok(())
+}
+
+/// Like [`create_and_configure_account`], but for a mint with confidential
+/// fees: the token account also gets the `ConfidentialTransferFeeAmount`
+/// extension that accumulates withheld fees.
+pub async fn create_and_configure_fee_account(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    owner: &Keypair,
+    mint: &Pubkey,
+) -> CtResult<()> {
+    let create_ata_ix = create_associated_token_account(
+        &payer.pubkey(),
+        &owner.pubkey(),
+        mint,
+        &spl_token_2022::id(),
+    );
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ata_ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+
+    configure_account_with_extensions(
+        client,
+        payer,
+        owner,
+        mint,
+        &[ExtensionType::ConfidentialTransferFeeAmount],
+    )
+    .await?;
     Ok(())
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,107 @@
+//! Account scaffolding shared by the examples: load a keypair from the
+//! environment, create a confidential-transfer mint, and create + configure a
+//! token account for confidential transfers.
+
+use crate::configure::configure_account_for_confidential_transfers;
+use crate::types::*;
+use solana_client::rpc_client::RpcClient;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_system_interface::instruction as system_instruction;
+use solana_transaction::Transaction;
+use solana_zk_sdk::encryption::elgamal::ElGamalKeypair;
+use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
+use spl_associated_token_account::instruction::create_associated_token_account;
+use spl_token_2022::{
+    extension::{confidential_transfer::instruction::initialize_mint, ExtensionType},
+    instruction::initialize_mint as initialize_mint_base,
+    state::Mint,
+};
+
+/// Load a 64-byte JSON keypair array (solana-keygen format) from env var `var`.
+pub fn load_keypair_env(var: &str) -> CtResult<Keypair> {
+    let json = std::env::var(var).map_err(|_| format!("{var} environment variable not set"))?;
+    let bytes: Vec<u8> = serde_json::from_str(&json).map_err(|e| format!("parse {var}: {e}"))?;
+    if bytes.len() != 64 {
+        return Err(format!("invalid {var}: expected 64 bytes, got {}", bytes.len()).into());
+    }
+    let mut secret_key = [0u8; 32];
+    secret_key.copy_from_slice(&bytes[0..32]);
+    Ok(Keypair::new_from_array(secret_key))
+}
+
+/// Create a Token-2022 mint with the confidential-transfer extension:
+/// auto-approve new accounts, and a freshly generated auditor ElGamal key.
+pub fn create_confidential_mint(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    decimals: u8,
+) -> CtResult<Keypair> {
+    let mint = Keypair::new();
+    let space =
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::ConfidentialTransferMint])?;
+    let rent = client.get_minimum_balance_for_rent_exemption(space)?;
+
+    let auditor_elgamal = ElGamalKeypair::new_rand();
+    let auditor_pubkey_pod: PodElGamalPubkey = (*auditor_elgamal.pubkey()).into();
+
+    let create_account_ix = system_instruction::create_account(
+        &payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &spl_token_2022::id(),
+    );
+    let init_ct_ix = initialize_mint(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        None,
+        true,
+        Some(auditor_pubkey_pod),
+    )?;
+    let init_mint_ix = initialize_mint_base(
+        &spl_token_2022::id(),
+        &mint.pubkey(),
+        &payer.pubkey(),
+        None,
+        decimals,
+    )?;
+
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[create_account_ix, init_ct_ix, init_mint_ix],
+        Some(&payer.pubkey()),
+        &[payer, &mint],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+    Ok(mint)
+}
+
+/// Create `owner`'s associated token account for `mint` and configure it for
+/// confidential transfers.
+pub async fn create_and_configure_account(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    owner: &Keypair,
+    mint: &Pubkey,
+) -> CtResult<()> {
+    let create_ata_ix = create_associated_token_account(
+        &payer.pubkey(),
+        &owner.pubkey(),
+        mint,
+        &spl_token_2022::id(),
+    );
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[create_ata_ix],
+        Some(&payer.pubkey()),
+        &[payer],
+        blockhash,
+    );
+    client.send_and_confirm_transaction(&tx)?;
+
+    configure_account_for_confidential_transfers(client, payer, owner, mint).await?;
+    Ok(())
+}

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -9,11 +9,11 @@
 use crate::types::*;
 use solana_address::Address;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signature, Signer},
-    transaction::Transaction,
-};
+use solana_pubkey::Pubkey;
+use solana_keypair::Keypair;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use solana_system_interface::instruction as system_instruction;
 use solana_zk_elgamal_proof_interface::{
     instruction::{close_context_state, ContextStateInfo, ProofInstruction},
@@ -47,7 +47,7 @@ use spl_token_confidential_transfer_proof_generation::transfer::transfer_split_p
 use std::mem::size_of;
 
 const ZK_PROOF_PROGRAM_ID: Pubkey =
-    solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
+    solana_pubkey::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
 
 #[allow(clippy::too_many_arguments)]
 pub async fn transfer_confidential(
@@ -364,7 +364,7 @@ pub async fn transfer_confidential_with_progress(
 /// Send a single tx, return the signature.
 fn send_tx(
     client: &RpcClient,
-    ixs: &[solana_sdk::instruction::Instruction],
+    ixs: &[solana_instruction::Instruction],
     signers: &[&dyn Signer],
     payer: &Pubkey,
 ) -> CtResult<Signature> {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -46,7 +46,7 @@ use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation
 use spl_token_confidential_transfer_proof_generation::transfer::transfer_split_proof_data;
 use std::mem::size_of;
 
-const ZK_PROOF_PROGRAM_ID: Pubkey =
+pub(crate) const ZK_PROOF_PROGRAM_ID: Pubkey =
     solana_pubkey::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
 
 #[allow(clippy::too_many_arguments)]
@@ -362,7 +362,7 @@ pub async fn transfer_confidential_with_progress(
 // ----------------------------------------------------------------------------
 
 /// Send a single tx, return the signature.
-fn send_tx(
+pub(crate) fn send_tx(
     client: &RpcClient,
     ixs: &[solana_instruction::Instruction],
     signers: &[&dyn Signer],

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1,11 +1,10 @@
-//! Confidential transfer between accounts (bypass mode).
+//! Confidential transfer between accounts.
 //!
 //! Generates the three transfer proofs (equality, ciphertext-validity, range)
-//! using `spl-token-confidential-transfer-proof-generation = 0.6.0`
-//! (`solana-zk-sdk = 6.0.1`), pre-verifies each into a context state account,
-//! then references those accounts in `spl-token-2022 = 10.0.0`'s transfer ix
-//! via `ProofLocation::ContextStateAccount`. The 4.0 ↔ 6.0.1 boundary is
-//! crossed by zero-copy byte casts of POD types.
+//! with `spl-token-confidential-transfer-proof-generation = 0.6.0`
+//! (solana-zk-sdk 6.0.1), pre-verifies each into a context state account, then
+//! references those accounts in spl-token-2022 11.0.0's transfer ix via
+//! `ProofLocation::ContextStateAccount`.
 
 use crate::types::*;
 use solana_address::Address;
@@ -28,9 +27,7 @@ use solana_zk_sdk::encryption::{
     auth_encryption::{AeCiphertext, AeKey},
     elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
 };
-use solana_zk_sdk_pod::encryption::elgamal::{
-    PodElGamalCiphertext as PodElGamalCiphertextV6, PodElGamalPubkey as PodElGamalPubkeyV6,
-};
+use solana_zk_sdk_pod::encryption::{auth_encryption::PodAeCiphertext, elgamal::PodElGamalPubkey};
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
     extension::{
@@ -43,13 +40,6 @@ use spl_token_2022::{
         },
         BaseStateWithExtensions, StateWithExtensions,
     },
-    solana_zk_sdk::encryption::pod::{
-        auth_encryption::PodAeCiphertext as PodAeCiphertextLegacy,
-        elgamal::{
-            PodElGamalCiphertext as PodElGamalCiphertextLegacy,
-            PodElGamalPubkey as PodElGamalPubkeyLegacy,
-        },
-    },
     state::{Account as TokenAccount, Mint},
 };
 use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
@@ -58,17 +48,6 @@ use std::mem::size_of;
 
 const ZK_PROOF_PROGRAM_ID: Pubkey =
     solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
-
-/// Byte offset of the proof data inside an spl-record account
-/// (`RecordData::WRITABLE_START_INDEX`: 1-byte version + 32-byte authority).
-const RECORD_PROOF_OFFSET: u32 = 33;
-
-/// Per-tx write payloads for staging the proof into a record account, sized to
-/// stay under the 1232-byte tx limit. The first write also carries
-/// create_account + initialize, so it gets a smaller budget; the final write
-/// also carries the context create + verify-from-account, which it has room for.
-const RECORD_FIRST_CHUNK: usize = 750;
-const RECORD_WRITE_CHUNK: usize = 900;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn transfer_confidential(
@@ -121,29 +100,25 @@ pub async fn transfer_confidential_with_progress(
     let recipient_token_account =
         get_associated_token_address_with_program_id(recipient, mint, &spl_token_2022::id());
 
-    // ----- Recipient ElGamal pubkey (legacy → 6.0.1 byte-cast) -----
+    // ----- Recipient ElGamal pubkey -----
     let recipient_acc_data = client.get_account(&recipient_token_account)?;
     let recipient_acc = StateWithExtensions::<TokenAccount>::unpack(&recipient_acc_data.data)?;
     let recipient_ext = recipient_acc.get_extension::<ConfidentialTransferAccount>()?;
-    let recipient_elgamal_pubkey: ElGamalPubkey =
-        cast_elgamal_pubkey_legacy_to_v6(&recipient_ext.elgamal_pubkey)?
-            .try_into()
-            .map_err(|e| format!("recipient ElGamal pubkey: {e:?}"))?;
+    let recipient_elgamal_pubkey: ElGamalPubkey = recipient_ext
+        .elgamal_pubkey
+        .try_into()
+        .map_err(|e| format!("recipient ElGamal pubkey: {e:?}"))?;
 
     // ----- Auditor ElGamal pubkey (optional) -----
     let mint_acc_data = client.get_account(mint)?;
     let mint_acc = StateWithExtensions::<Mint>::unpack(&mint_acc_data.data)?;
     let mint_ext = mint_acc.get_extension::<ConfidentialTransferMint>()?;
-    let auditor_elgamal_pubkey: Option<ElGamalPubkey> = {
-        let pod_opt: Option<PodElGamalPubkeyLegacy> = mint_ext.auditor_elgamal_pubkey.into();
-        pod_opt
-            .map(|pod| -> CtResult<ElGamalPubkey> {
-                let v6 = cast_elgamal_pubkey_legacy_to_v6(&pod)?;
-                v6.try_into()
-                    .map_err(|e| format!("auditor ElGamal pubkey: {e:?}").into())
+    let auditor_elgamal_pubkey: Option<ElGamalPubkey> =
+        Option::<PodElGamalPubkey>::from(mint_ext.auditor_elgamal_pubkey)
+            .map(|pod| {
+                ElGamalPubkey::try_from(pod).map_err(|e| format!("auditor ElGamal pubkey: {e:?}"))
             })
-            .transpose()?
-    };
+            .transpose()?;
 
     phase(
         "derive-keys",
@@ -159,20 +134,22 @@ pub async fn transfer_confidential_with_progress(
     let sender_acc = StateWithExtensions::<TokenAccount>::unpack(&sender_acc_data.data)?;
     let sender_ext = sender_acc.get_extension::<ConfidentialTransferAccount>()?;
 
-    let current_available_v6: ElGamalCiphertext =
-        cast_elgamal_ciphertext_legacy_to_v6(&sender_ext.available_balance)?
-            .try_into()
-            .map_err(|e| format!("sender available balance: {e:?}"))?;
-    let current_decryptable_v6: AeCiphertext =
-        cast_ae_ciphertext_legacy_to_v6(&sender_ext.decryptable_available_balance)?;
+    let current_available: ElGamalCiphertext = sender_ext
+        .available_balance
+        .try_into()
+        .map_err(|e| format!("sender available balance: {e:?}"))?;
+    let current_decryptable: AeCiphertext = sender_ext
+        .decryptable_available_balance
+        .try_into()
+        .map_err(|e| format!("sender decryptable balance: {e:?}"))?;
 
     phase(
         "generate-proofs",
         "Generating equality, ciphertext-validity, and range proofs (zk-sdk 6.0.1)",
     );
     let proof_data = transfer_split_proof_data(
-        &current_available_v6,
-        &current_decryptable_v6,
+        &current_available,
+        &current_decryptable,
         amount,
         &sender_elgamal,
         &sender_aes,
@@ -183,15 +160,25 @@ pub async fn transfer_confidential_with_progress(
 
     phase(
         "create-proof-accounts",
-        "Allocating + verifying 3 proof context state accounts (3 transactions)",
+        "Allocating + verifying 3 proof context state accounts",
     );
 
     let mut signatures: Vec<Signature> = Vec::new();
 
-    // 1. Equality proof
+    // Build all three proof accounts up front so we can batch where possible.
     let equality_account = Keypair::new();
+    let validity_account = Keypair::new();
+    let range_account = Keypair::new();
+
     let equality_size = size_of::<ProofContextState<CiphertextCommitmentEqualityProofContext>>();
+    let validity_size =
+        size_of::<ProofContextState<BatchedGroupedCiphertext3HandlesValidityProofContext>>();
+    let range_size = size_of::<ProofContextState<BatchedRangeProofContext>>();
+
     let equality_rent = client.get_minimum_balance_for_rent_exemption(equality_size)?;
+    let validity_rent = client.get_minimum_balance_for_rent_exemption(validity_size)?;
+    let range_rent = client.get_minimum_balance_for_rent_exemption(range_size)?;
+
     let equality_create_ix = system_instruction::create_account(
         &payer.pubkey(),
         &equality_account.pubkey(),
@@ -199,31 +186,6 @@ pub async fn transfer_confidential_with_progress(
         equality_size as u64,
         &ZK_PROOF_PROGRAM_ID,
     );
-    let equality_verify_ix = ProofInstruction::VerifyCiphertextCommitmentEquality
-        .encode_verify_proof(
-            Some(ContextStateInfo {
-                context_state_account: &Address::from(equality_account.pubkey().to_bytes()),
-                context_state_authority: &Address::from(sender.pubkey().to_bytes()),
-            }),
-            &proof_data.equality_proof_data,
-        );
-    // sender is the context-state authority but verify_proof records it as a
-    // readonly non-signer; only payer (fee + create funder) and the new
-    // proof account itself must sign.
-    let sig = send_tx(
-        client,
-        &[equality_create_ix, equality_verify_ix],
-        &[payer, &equality_account],
-        &payer.pubkey(),
-    )?;
-    sig_event("equality-proof-account", &sig);
-    signatures.push(sig);
-
-    // 2. Ciphertext validity proof
-    let validity_account = Keypair::new();
-    let validity_size =
-        size_of::<ProofContextState<BatchedGroupedCiphertext3HandlesValidityProofContext>>();
-    let validity_rent = client.get_minimum_balance_for_rent_exemption(validity_size)?;
     let validity_create_ix = system_instruction::create_account(
         &payer.pubkey(),
         &validity_account.pubkey(),
@@ -231,35 +193,6 @@ pub async fn transfer_confidential_with_progress(
         validity_size as u64,
         &ZK_PROOF_PROGRAM_ID,
     );
-    let validity_verify_ix = ProofInstruction::VerifyBatchedGroupedCiphertext3HandlesValidity
-        .encode_verify_proof(
-            Some(ContextStateInfo {
-                context_state_account: &Address::from(validity_account.pubkey().to_bytes()),
-                context_state_authority: &Address::from(sender.pubkey().to_bytes()),
-            }),
-            &proof_data
-                .ciphertext_validity_proof_data_with_ciphertext
-                .proof_data,
-        );
-    let sig = send_tx(
-        client,
-        &[validity_create_ix, validity_verify_ix],
-        &[payer, &validity_account],
-        &payer.pubkey(),
-    )?;
-    sig_event("ciphertext-validity-proof-account", &sig);
-    signatures.push(sig);
-
-    // 3. Range proof — the inline U128 range proof (~1.4 KB) blows past the
-    // 1232-byte tx limit even on its own, so it can't ride in a verify ix.
-    // Stage it in an spl-record account, then verify *from* that account
-    // (encode_verify_proof_from_account) so the verify ix carries only account
-    // references. The context-account create + verify-from-account are appended
-    // to the final record write so they don't cost an extra transaction.
-    let record_account = Keypair::new();
-    let range_account = Keypair::new();
-    let range_size = size_of::<ProofContextState<BatchedRangeProofContext>>();
-    let range_rent = client.get_minimum_balance_for_rent_exemption(range_size)?;
     let range_create_ix = system_instruction::create_account(
         &payer.pubkey(),
         &range_account.pubkey(),
@@ -267,51 +200,81 @@ pub async fn transfer_confidential_with_progress(
         range_size as u64,
         &ZK_PROOF_PROGRAM_ID,
     );
-    let range_verify_ix = ProofInstruction::VerifyBatchedRangeProofU128
-        .encode_verify_proof_from_account(
-            Some(ContextStateInfo {
-                context_state_account: &Address::from(range_account.pubkey().to_bytes()),
-                context_state_authority: &Address::from(sender.pubkey().to_bytes()),
-            }),
-            &Address::from(record_account.pubkey().to_bytes()),
-            RECORD_PROOF_OFFSET,
-        );
-    let mut record_sigs = stage_range_proof_record(
-        client,
-        payer,
-        &record_account,
-        bytemuck::bytes_of(&proof_data.range_proof_data),
-        &[range_create_ix, range_verify_ix],
-        &[&range_account],
-    )?;
-    for (i, sig) in record_sigs.iter().enumerate() {
-        sig_event(&format!("range-proof-stage-{}", i + 1), sig);
-    }
-    signatures.append(&mut record_sigs);
 
-    phase("submit-transfer", "Submitting confidential transfer and closing proof accounts");
+    // Use payer (not sender) as the context-state authority on all three
+    // proof accounts. This keeps sender out of the verify txs' account_keys
+    // — saves 32 bytes per tx, which is the difference between fitting and
+    // overflowing the 1232-byte legacy size limit on `range_verify`. Closes
+    // are then signed by payer too.
+    let payer_addr: Address = payer.pubkey().to_bytes().into();
+    let equality_verify_ix = ProofInstruction::VerifyCiphertextCommitmentEquality
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &Address::from(equality_account.pubkey().to_bytes()),
+                context_state_authority: &payer_addr,
+            }),
+            &proof_data.equality_proof_data,
+        );
+    let validity_verify_ix = ProofInstruction::VerifyBatchedGroupedCiphertext3HandlesValidity
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &Address::from(validity_account.pubkey().to_bytes()),
+                context_state_authority: &payer_addr,
+            }),
+            &proof_data
+                .ciphertext_validity_proof_data_with_ciphertext
+                .proof_data,
+        );
+    let range_verify_ix = ProofInstruction::VerifyBatchedRangeProofU128.encode_verify_proof(
+        Some(ContextStateInfo {
+            context_state_account: &Address::from(range_account.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
+        }),
+        &proof_data.range_proof_data,
+    );
+
+    // Tx 1: create all 3 proof accounts + verify the validity proof. The
+    // validity proof's context data is the largest of eq/val (~544 vs ~320),
+    // so it pairs with the small creates here; equality goes alongside the
+    // transfer below where there's headroom.
+    let sig = send_tx(
+        client,
+        &[
+            equality_create_ix,
+            validity_create_ix,
+            range_create_ix,
+            validity_verify_ix,
+        ],
+        &[payer, &equality_account, &validity_account, &range_account],
+        &payer.pubkey(),
+    )?;
+    sig_event("create-proof-accounts+verify-validity", &sig);
+    signatures.push(sig);
+
+    // Tx 2: verify the range proof on its own. ~1006-byte verify ix; with
+    // payer as authority and 3 account keys, lands at ~1206 bytes — under
+    // Solana's 1232-byte legacy size limit, but only just.
+    let sig = send_tx(client, &[range_verify_ix], &[payer], &payer.pubkey())?;
+    sig_event("range-proof-account-verify", &sig);
+    signatures.push(sig);
+
+    phase("submit-transfer", "Submitting confidential transfer instruction");
 
     // New decryptable available balance for the sender (post-transfer).
-    let current_avail_plaintext = current_decryptable_v6
+    let current_avail_plaintext = current_decryptable
         .decrypt(&sender_aes)
         .ok_or("decrypt current available")?;
     let new_avail_plaintext = current_avail_plaintext
         .checked_sub(amount)
         .ok_or("insufficient available balance")?;
-    let new_decryptable_v6 = sender_aes.encrypt(new_avail_plaintext);
-    let new_decryptable_legacy: PodAeCiphertextLegacy =
-        cast_ae_ciphertext_v6_to_legacy(&new_decryptable_v6);
+    let new_decryptable: PodAeCiphertext = sender_aes.encrypt(new_avail_plaintext).into();
 
-    let auditor_lo_v6 = proof_data
+    let auditor_lo = proof_data
         .ciphertext_validity_proof_data_with_ciphertext
         .ciphertext_lo;
-    let auditor_hi_v6 = proof_data
+    let auditor_hi = proof_data
         .ciphertext_validity_proof_data_with_ciphertext
         .ciphertext_hi;
-    let auditor_lo_legacy: PodElGamalCiphertextLegacy =
-        cast_elgamal_ciphertext_v6_to_legacy(&auditor_lo_v6);
-    let auditor_hi_legacy: PodElGamalCiphertextLegacy =
-        cast_elgamal_ciphertext_v6_to_legacy(&auditor_hi_v6);
 
     let equality_loc: ProofLocation<CiphertextCommitmentEqualityProofData> =
         ProofLocation::ContextStateAccount(&equality_account.pubkey());
@@ -325,9 +288,9 @@ pub async fn transfer_confidential_with_progress(
         &sender_token_account,
         mint,
         &recipient_token_account,
-        &new_decryptable_legacy,
-        &auditor_lo_legacy,
-        &auditor_hi_legacy,
+        &new_decryptable,
+        &auditor_lo,
+        &auditor_hi,
         &sender.pubkey(),
         &[],
         equality_loc,
@@ -335,33 +298,50 @@ pub async fn transfer_confidential_with_progress(
         range_loc,
     )?;
 
-    // Close all three proof context accounts and the record account in the same
-    // transaction as the transfer: the transfer consumes the verified proofs,
-    // then the closes reclaim rent. Saves four standalone transactions.
-    let payer_addr = Address::from(payer.pubkey().to_bytes());
-    let sender_addr = Address::from(sender.pubkey().to_bytes());
-    let close_ctx = |ctx: &Pubkey| {
-        close_context_state(
-            ContextStateInfo {
-                context_state_account: &Address::from(ctx.to_bytes()),
-                context_state_authority: &sender_addr,
-            },
-            &payer_addr,
-        )
-    };
-    let ixs = [
-        transfer_ix,
-        close_ctx(&equality_account.pubkey()),
-        close_ctx(&validity_account.pubkey()),
-        close_ctx(&range_account.pubkey()),
-        spl_record::instruction::close_account(
-            &record_account.pubkey(),
-            &payer.pubkey(),
-            &payer.pubkey(),
-        ),
-    ];
-    let sig = send_tx(client, &ixs, &[payer, sender], &payer.pubkey())?;
-    sig_event("transfer-and-close", &sig);
+    phase(
+        "verify-eq+transfer+close",
+        "Verifying equality proof, submitting transfer, closing proof accounts",
+    );
+
+    // Tx 3: equality verify + transfer + 3 closes. Equality is the smallest
+    // verify (~328-byte ix), and transfer + 3 closes is only ~210 bytes of ix
+    // data, so this all fits in one tx (~1015 bytes). Close ixs use payer as
+    // the context-state authority so only payer signs the closes; sender
+    // still signs because it's the transfer's token-account authority.
+    let close_eq = close_context_state(
+        ContextStateInfo {
+            context_state_account: &Address::from(equality_account.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
+        },
+        &payer_addr,
+    );
+    let close_val = close_context_state(
+        ContextStateInfo {
+            context_state_account: &Address::from(validity_account.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
+        },
+        &payer_addr,
+    );
+    let close_range = close_context_state(
+        ContextStateInfo {
+            context_state_account: &Address::from(range_account.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
+        },
+        &payer_addr,
+    );
+    let sig = send_tx(
+        client,
+        &[
+            equality_verify_ix,
+            transfer_ix,
+            close_eq,
+            close_val,
+            close_range,
+        ],
+        &[payer, sender],
+        &payer.pubkey(),
+    )?;
+    sig_event("verify-eq+transfer+close", &sig);
     signatures.push(sig);
 
     emit(
@@ -381,85 +361,6 @@ pub async fn transfer_confidential_with_progress(
 // Helpers
 // ----------------------------------------------------------------------------
 
-/// Create an spl-record account owned by `payer` (as record authority) and
-/// write `proof_bytes` into it in tx-sized chunks. The first tx allocates +
-/// initializes + writes the first chunk; subsequent chunks are write-only.
-/// `trailing_ixs` (with `trailing_signers`) are appended to the final write tx
-/// so the caller's create-context + verify-from-account ride along for free.
-/// Returns one signature per transaction sent.
-fn stage_range_proof_record(
-    client: &RpcClient,
-    payer: &dyn Signer,
-    record_account: &Keypair,
-    proof_bytes: &[u8],
-    trailing_ixs: &[solana_sdk::instruction::Instruction],
-    trailing_signers: &[&dyn Signer],
-) -> CtResult<Vec<Signature>> {
-    let space = proof_bytes.len() + RECORD_PROOF_OFFSET as usize;
-    let rent = client.get_minimum_balance_for_rent_exemption(space)?;
-
-    if proof_bytes.is_empty() {
-        return Err("range proof had no bytes to stage".into());
-    }
-
-    // First chunk is smaller to leave room for create_account + initialize.
-    let first_len = proof_bytes.len().min(RECORD_FIRST_CHUNK);
-    let (first, rest) = proof_bytes.split_at(first_len);
-
-    let mut sigs = Vec::new();
-    let mut offset = 0usize;
-
-    // tx 1: create + initialize + write the first chunk. We never append the
-    // trailing ixs here (create_account + initialize already make this tx the
-    // heaviest), so it can't overflow on a large single-chunk proof.
-    sigs.push(send_tx(
-        client,
-        &[
-            system_instruction::create_account(
-                &payer.pubkey(),
-                &record_account.pubkey(),
-                rent,
-                space as u64,
-                &spl_record::id(),
-            ),
-            spl_record::instruction::initialize(&record_account.pubkey(), &payer.pubkey()),
-            spl_record::instruction::write(&record_account.pubkey(), &payer.pubkey(), 0, first),
-        ],
-        &[payer, record_account],
-        &payer.pubkey(),
-    )?);
-    offset += first.len();
-
-    // Remaining chunks are write-only; the trailing ixs ride the last one.
-    let mut chunks = rest.chunks(RECORD_WRITE_CHUNK).peekable();
-    let mut trailing_attached = false;
-    while let Some(chunk) = chunks.next() {
-        let mut ixs = vec![spl_record::instruction::write(
-            &record_account.pubkey(),
-            &payer.pubkey(),
-            offset as u64,
-            chunk,
-        )];
-        let mut signers: Vec<&dyn Signer> = vec![payer];
-        if chunks.peek().is_none() {
-            ixs.extend_from_slice(trailing_ixs);
-            signers.extend_from_slice(trailing_signers);
-            trailing_attached = true;
-        }
-        sigs.push(send_tx(client, &ixs, &signers, &payer.pubkey())?);
-        offset += chunk.len();
-    }
-
-    // Single-chunk proof: no write-only tx existed to carry the trailing ixs.
-    if !trailing_attached {
-        let mut signers: Vec<&dyn Signer> = vec![payer];
-        signers.extend_from_slice(trailing_signers);
-        sigs.push(send_tx(client, trailing_ixs, &signers, &payer.pubkey())?);
-    }
-
-    Ok(sigs)
-}
-
 /// Send a single tx, return the signature.
 fn send_tx(
     client: &RpcClient,
@@ -470,42 +371,4 @@ fn send_tx(
     let blockhash = client.get_latest_blockhash()?;
     let tx = Transaction::new_signed_with_payer(ixs, Some(payer), signers, blockhash);
     Ok(client.send_and_confirm_transaction(&tx)?)
-}
-
-// Byte-cast helpers across the 4.0 / 6.0.1 boundary. POD wire format is
-// identical for these types; the Rust types are just version-tagged wrappers.
-
-fn cast_elgamal_pubkey_legacy_to_v6(
-    legacy: &PodElGamalPubkeyLegacy,
-) -> CtResult<PodElGamalPubkeyV6> {
-    let bytes: [u8; 32] = bytemuck::bytes_of(legacy)
-        .try_into()
-        .map_err(|_| "PodElGamalPubkey size")?;
-    Ok(PodElGamalPubkeyV6(bytes))
-}
-
-fn cast_elgamal_ciphertext_legacy_to_v6(
-    legacy: &PodElGamalCiphertextLegacy,
-) -> CtResult<PodElGamalCiphertextV6> {
-    let bytes: [u8; 64] = bytemuck::bytes_of(legacy)
-        .try_into()
-        .map_err(|_| "PodElGamalCiphertext size")?;
-    Ok(PodElGamalCiphertextV6(bytes))
-}
-
-fn cast_elgamal_ciphertext_v6_to_legacy(
-    v6: &PodElGamalCiphertextV6,
-) -> PodElGamalCiphertextLegacy {
-    PodElGamalCiphertextLegacy::from(v6.0)
-}
-
-fn cast_ae_ciphertext_legacy_to_v6(legacy: &PodAeCiphertextLegacy) -> CtResult<AeCiphertext> {
-    let bytes: [u8; 36] = bytemuck::bytes_of(legacy)
-        .try_into()
-        .map_err(|_| "PodAeCiphertext size")?;
-    AeCiphertext::from_bytes(&bytes).ok_or_else(|| "decode AeCiphertext bytes".into())
-}
-
-fn cast_ae_ciphertext_v6_to_legacy(v6: &AeCiphertext) -> PodAeCiphertextLegacy {
-    PodAeCiphertextLegacy::from(v6.to_bytes())
 }

--- a/src/transfer_with_fee.rs
+++ b/src/transfer_with_fee.rs
@@ -1,0 +1,469 @@
+//! Confidential transfer on a mint with confidential transfer fees.
+//!
+//! The fee-aware transfer needs five proofs instead of three: equality,
+//! transfer-amount ciphertext validity (3 handles), percentage-with-cap (the
+//! fee actually matches the mint's fee parameters), fee ciphertext validity
+//! (2 handles: recipient + withdraw-withheld authority), and a U256 range
+//! proof covering the amount, the fee, and the remaining balance together.
+//!
+//! Each proof is pre-verified into a context state account and the transfer
+//! ix references them via `ProofLocation::ContextStateAccount`. The U256
+//! range proof is the catch: its verify instruction is ~1250 bytes of proof
+//! data alone, over the 1232-byte transaction limit, so it cannot be sent
+//! inline at all. Instead the proof bytes are staged into an spl-record
+//! account across multiple write transactions and verified from there with
+//! `encode_verify_proof_from_account`.
+
+use crate::transfer::{send_tx, ZK_PROOF_PROGRAM_ID};
+use crate::types::*;
+use solana_address::Address;
+use solana_client::rpc_client::RpcClient;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_system_interface::instruction as system_instruction;
+use solana_zk_elgamal_proof_interface::{
+    instruction::{close_context_state, ContextStateInfo, ProofInstruction},
+    proof_data::{
+        BatchedGroupedCiphertext2HandlesValidityProofContext,
+        BatchedGroupedCiphertext3HandlesValidityProofContext, BatchedRangeProofContext,
+        CiphertextCommitmentEqualityProofContext, PercentageWithCapProofContext,
+    },
+    state::ProofContextState,
+};
+use solana_zk_sdk::encryption::{
+    auth_encryption::{AeCiphertext, AeKey},
+    elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+};
+use solana_zk_sdk_pod::encryption::{auth_encryption::PodAeCiphertext, elgamal::PodElGamalPubkey};
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token_2022::{
+    extension::{
+        confidential_transfer::{
+            instruction::{
+                inner_transfer_with_fee, BatchedGroupedCiphertext2HandlesValidityProofData,
+                BatchedGroupedCiphertext3HandlesValidityProofData, BatchedRangeProofU256Data,
+                CiphertextCommitmentEqualityProofData, PercentageWithCapProofData,
+            },
+            ConfidentialTransferAccount, ConfidentialTransferMint,
+        },
+        confidential_transfer_fee::ConfidentialTransferFeeConfig,
+        transfer_fee::TransferFeeConfig,
+        BaseStateWithExtensions, StateWithExtensions,
+    },
+    state::{Account as TokenAccount, Mint},
+};
+use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
+use spl_token_confidential_transfer_proof_generation::transfer_with_fee::transfer_with_fee_split_proof_data;
+use std::mem::size_of;
+
+/// Byte offset of the proof data inside an spl-record account
+/// (`RecordData::WRITABLE_START_INDEX`: 1-byte version + 32-byte authority).
+const RECORD_PROOF_OFFSET: u32 = 33;
+
+/// Per-tx write payloads for staging the proof into a record account, sized to
+/// stay under the 1232-byte tx limit. The first write also carries
+/// create_account + initialize, so it gets a smaller budget; the final write
+/// also carries the context create + verify-from-account, which it has room
+/// for.
+const RECORD_FIRST_CHUNK: usize = 750;
+const RECORD_WRITE_CHUNK: usize = 900;
+
+/// Transfer `amount` confidentially on a mint carrying `TransferFeeConfig` +
+/// `ConfidentialTransferFeeConfig`. The fee (per the mint's parameters for
+/// the current epoch) is withheld on the recipient account, encrypted under
+/// the mint's withdraw-withheld authority ElGamal key.
+pub async fn transfer_confidential_with_fee(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    sender: &Keypair,
+    mint: &Pubkey,
+    recipient: &Pubkey,
+    amount: u64,
+) -> MultiSigResult {
+    let sender_token_account = get_associated_token_address_with_program_id(
+        &sender.pubkey(),
+        mint,
+        &spl_token_2022::id(),
+    );
+    let recipient_token_account =
+        get_associated_token_address_with_program_id(recipient, mint, &spl_token_2022::id());
+
+    // ----- Recipient ElGamal pubkey -----
+    let recipient_acc_data = client.get_account(&recipient_token_account)?;
+    let recipient_acc = StateWithExtensions::<TokenAccount>::unpack(&recipient_acc_data.data)?;
+    let recipient_ext = recipient_acc.get_extension::<ConfidentialTransferAccount>()?;
+    let recipient_elgamal_pubkey: ElGamalPubkey = recipient_ext
+        .elgamal_pubkey
+        .try_into()
+        .map_err(|e| format!("recipient ElGamal pubkey: {e:?}"))?;
+
+    // ----- Mint state: auditor key, fee parameters, withheld authority key -----
+    let mint_acc_data = client.get_account(mint)?;
+    let mint_acc = StateWithExtensions::<Mint>::unpack(&mint_acc_data.data)?;
+
+    let mint_ext = mint_acc.get_extension::<ConfidentialTransferMint>()?;
+    let auditor_elgamal_pubkey: Option<ElGamalPubkey> =
+        Option::<PodElGamalPubkey>::from(mint_ext.auditor_elgamal_pubkey)
+            .map(|pod| {
+                ElGamalPubkey::try_from(pod).map_err(|e| format!("auditor ElGamal pubkey: {e:?}"))
+            })
+            .transpose()?;
+
+    let fee_config = mint_acc.get_extension::<TransferFeeConfig>()?;
+    let epoch = client.get_epoch_info()?.epoch;
+    let epoch_fee = fee_config.get_epoch_fee(epoch);
+    let fee_rate_basis_points: u16 = epoch_fee.transfer_fee_basis_points.into();
+    let maximum_fee: u64 = epoch_fee.maximum_fee.into();
+
+    let ct_fee_config = mint_acc.get_extension::<ConfidentialTransferFeeConfig>()?;
+    let withheld_authority_elgamal_pubkey: ElGamalPubkey = ct_fee_config
+        .withdraw_withheld_authority_elgamal_pubkey
+        .try_into()
+        .map_err(|e| format!("withdraw-withheld authority ElGamal pubkey: {e:?}"))?;
+
+    // ----- Sender keys and balances -----
+    let sender_elgamal = ElGamalKeypair::new_from_signer(sender, &sender_token_account.to_bytes())
+        .map_err(|e| format!("derive sender ElGamal: {e}"))?;
+    let sender_aes = AeKey::new_from_signer(sender, &sender_token_account.to_bytes())
+        .map_err(|e| format!("derive sender AES: {e}"))?;
+
+    let sender_acc_data = client.get_account(&sender_token_account)?;
+    let sender_acc = StateWithExtensions::<TokenAccount>::unpack(&sender_acc_data.data)?;
+    let sender_ext = sender_acc.get_extension::<ConfidentialTransferAccount>()?;
+
+    let current_available: ElGamalCiphertext = sender_ext
+        .available_balance
+        .try_into()
+        .map_err(|e| format!("sender available balance: {e:?}"))?;
+    let current_decryptable: AeCiphertext = sender_ext
+        .decryptable_available_balance
+        .try_into()
+        .map_err(|e| format!("sender decryptable balance: {e:?}"))?;
+
+    println!(
+        "🔐 Generating transfer-with-fee proofs for {amount} base units \
+         (fee: {fee_rate_basis_points} bps, max {maximum_fee})..."
+    );
+    let proof_data = transfer_with_fee_split_proof_data(
+        &current_available,
+        &current_decryptable,
+        amount,
+        &sender_elgamal,
+        &sender_aes,
+        &recipient_elgamal_pubkey,
+        auditor_elgamal_pubkey.as_ref(),
+        &withheld_authority_elgamal_pubkey,
+        fee_rate_basis_points,
+        maximum_fee,
+    )
+    .map_err(|e| format!("transfer_with_fee_split_proof_data: {e}"))?;
+
+    // ----- Stage the five proofs into context state accounts -----
+    let mut signatures: Vec<Signature> = Vec::new();
+
+    let equality_account = Keypair::new();
+    let validity_account = Keypair::new();
+    let fee_sigma_account = Keypair::new();
+    let fee_validity_account = Keypair::new();
+    let range_account = Keypair::new();
+
+    let payer_addr: Address = payer.pubkey().to_bytes().into();
+    let equality_addr = Address::from(equality_account.pubkey().to_bytes());
+    let validity_addr = Address::from(validity_account.pubkey().to_bytes());
+    let fee_sigma_addr = Address::from(fee_sigma_account.pubkey().to_bytes());
+    let fee_validity_addr = Address::from(fee_validity_account.pubkey().to_bytes());
+    let range_addr = Address::from(range_account.pubkey().to_bytes());
+    // Tx 1: create all five context accounts (their verify ixs won't all fit
+    // alongside, but the creates are small and share one tx fine).
+    let create_ix =
+        |account: &Keypair, space: usize| -> CtResult<solana_instruction::Instruction> {
+            let rent = client.get_minimum_balance_for_rent_exemption(space)?;
+            Ok(system_instruction::create_account(
+                &payer.pubkey(),
+                &account.pubkey(),
+                rent,
+                space as u64,
+                &ZK_PROOF_PROGRAM_ID,
+            ))
+        };
+    let sig = send_tx(
+        client,
+        &[
+            create_ix(
+                &equality_account,
+                size_of::<ProofContextState<CiphertextCommitmentEqualityProofContext>>(),
+            )?,
+            create_ix(
+                &validity_account,
+                size_of::<
+                    ProofContextState<BatchedGroupedCiphertext3HandlesValidityProofContext>,
+                >(),
+            )?,
+            create_ix(
+                &fee_sigma_account,
+                size_of::<ProofContextState<PercentageWithCapProofContext>>(),
+            )?,
+            create_ix(
+                &fee_validity_account,
+                size_of::<
+                    ProofContextState<BatchedGroupedCiphertext2HandlesValidityProofContext>,
+                >(),
+            )?,
+            create_ix(
+                &range_account,
+                size_of::<ProofContextState<BatchedRangeProofContext>>(),
+            )?,
+        ],
+        &[
+            payer,
+            &equality_account,
+            &validity_account,
+            &fee_sigma_account,
+            &fee_validity_account,
+            &range_account,
+        ],
+        &payer.pubkey(),
+    )?;
+    signatures.push(sig);
+    println!("  created 5 proof context accounts [{sig}]");
+
+    // Txs 2-5: verify the four "small" proofs, one per tx. Some pairs would
+    // fit together, but one-per-tx keeps every tx comfortably under the size
+    // limit for all fee parameter shapes.
+    let equality_verify_ix = ProofInstruction::VerifyCiphertextCommitmentEquality
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &equality_addr,
+                context_state_authority: &payer_addr,
+            }),
+            &proof_data.equality_proof_data,
+        );
+    let validity_verify_ix = ProofInstruction::VerifyBatchedGroupedCiphertext3HandlesValidity
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &validity_addr,
+                context_state_authority: &payer_addr,
+            }),
+            &proof_data
+                .transfer_amount_ciphertext_validity_proof_data_with_ciphertext
+                .proof_data,
+        );
+    let fee_sigma_verify_ix = ProofInstruction::VerifyPercentageWithCap.encode_verify_proof(
+        Some(ContextStateInfo {
+                context_state_account: &fee_sigma_addr,
+                context_state_authority: &payer_addr,
+            }),
+        &proof_data.percentage_with_cap_proof_data,
+    );
+    let fee_validity_verify_ix = ProofInstruction::VerifyBatchedGroupedCiphertext2HandlesValidity
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &fee_validity_addr,
+                context_state_authority: &payer_addr,
+            }),
+            &proof_data.fee_ciphertext_validity_proof_data,
+        );
+    for (label, ix) in [
+        ("equality", equality_verify_ix),
+        ("transfer-amount validity", validity_verify_ix),
+        ("fee percentage-with-cap", fee_sigma_verify_ix),
+        ("fee validity", fee_validity_verify_ix),
+    ] {
+        let sig = send_tx(client, &[ix], &[payer], &payer.pubkey())?;
+        signatures.push(sig);
+        println!("  verified {label} proof [{sig}]");
+    }
+
+    // U256 range proof: too big for any single tx, so stage the proof bytes
+    // through an spl-record account and verify from there. The final record
+    // write carries the verify-from-account ix.
+    let record_account = Keypair::new();
+    let range_verify_ix = ProofInstruction::VerifyBatchedRangeProofU256
+        .encode_verify_proof_from_account(
+            Some(ContextStateInfo {
+                context_state_account: &range_addr,
+                context_state_authority: &payer_addr,
+            }),
+            &Address::from(record_account.pubkey().to_bytes()),
+            RECORD_PROOF_OFFSET,
+        );
+    let record_sigs = stage_proof_record(
+        client,
+        payer,
+        &record_account,
+        bytemuck::bytes_of(&proof_data.range_proof_data),
+        &[range_verify_ix],
+        &[],
+    )?;
+    println!(
+        "  staged + verified U256 range proof via record account ({} txs)",
+        record_sigs.len()
+    );
+    signatures.extend(record_sigs);
+
+    // ----- Transfer with fee, then close everything -----
+    let current_avail_plaintext = current_decryptable
+        .decrypt(&sender_aes)
+        .ok_or("decrypt current available")?;
+    let new_avail_plaintext = current_avail_plaintext
+        .checked_sub(amount)
+        .ok_or("insufficient available balance")?;
+    let new_decryptable: PodAeCiphertext = sender_aes.encrypt(new_avail_plaintext).into();
+
+    let equality_loc: ProofLocation<CiphertextCommitmentEqualityProofData> =
+        ProofLocation::ContextStateAccount(&equality_account.pubkey());
+    let validity_loc: ProofLocation<BatchedGroupedCiphertext3HandlesValidityProofData> =
+        ProofLocation::ContextStateAccount(&validity_account.pubkey());
+    let fee_sigma_loc: ProofLocation<PercentageWithCapProofData> =
+        ProofLocation::ContextStateAccount(&fee_sigma_account.pubkey());
+    let fee_validity_loc: ProofLocation<BatchedGroupedCiphertext2HandlesValidityProofData> =
+        ProofLocation::ContextStateAccount(&fee_validity_account.pubkey());
+    let range_loc: ProofLocation<BatchedRangeProofU256Data> =
+        ProofLocation::ContextStateAccount(&range_account.pubkey());
+
+    let transfer_ix = inner_transfer_with_fee(
+        &spl_token_2022::id(),
+        &sender_token_account,
+        mint,
+        &recipient_token_account,
+        &new_decryptable,
+        &proof_data
+            .transfer_amount_ciphertext_validity_proof_data_with_ciphertext
+            .ciphertext_lo,
+        &proof_data
+            .transfer_amount_ciphertext_validity_proof_data_with_ciphertext
+            .ciphertext_hi,
+        &sender.pubkey(),
+        &[],
+        equality_loc,
+        validity_loc,
+        fee_sigma_loc,
+        fee_validity_loc,
+        range_loc,
+    )?;
+
+    // The fee-aware transfer burns considerably more compute than the default
+    // 200k-per-ix budget, so bump the limit.
+    let compute_ix = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
+
+    let close_ctx = |account_addr: &Address| {
+        close_context_state(
+            ContextStateInfo {
+                context_state_account: account_addr,
+                context_state_authority: &payer_addr,
+            },
+            &payer_addr,
+        )
+    };
+    let close_record_ix = spl_record::instruction::close_account(
+        &record_account.pubkey(),
+        &payer.pubkey(),
+        &payer.pubkey(),
+    );
+
+    let sig = send_tx(
+        client,
+        &[
+            compute_ix,
+            transfer_ix,
+            close_ctx(&equality_addr),
+            close_ctx(&validity_addr),
+            close_ctx(&fee_sigma_addr),
+            close_ctx(&fee_validity_addr),
+            close_ctx(&range_addr),
+            close_record_ix,
+        ],
+        &[payer, sender],
+        &payer.pubkey(),
+    )?;
+    signatures.push(sig);
+
+    println!(
+        "✅ Confidential transfer with fee complete with {} transactions [{}]",
+        signatures.len(),
+        sig
+    );
+    Ok(signatures)
+}
+
+/// Create an spl-record account owned by `payer` (as record authority) and
+/// write `proof_bytes` into it in tx-sized chunks. The first tx allocates +
+/// initializes + writes the first chunk; subsequent chunks are write-only.
+/// `trailing_ixs` (with `trailing_signers`) are appended to the final write tx
+/// so the caller's verify-from-account rides along for free. Returns one
+/// signature per transaction sent.
+fn stage_proof_record(
+    client: &RpcClient,
+    payer: &dyn Signer,
+    record_account: &Keypair,
+    proof_bytes: &[u8],
+    trailing_ixs: &[solana_instruction::Instruction],
+    trailing_signers: &[&dyn Signer],
+) -> CtResult<Vec<Signature>> {
+    let space = proof_bytes.len() + RECORD_PROOF_OFFSET as usize;
+    let rent = client.get_minimum_balance_for_rent_exemption(space)?;
+
+    if proof_bytes.is_empty() {
+        return Err("proof had no bytes to stage".into());
+    }
+
+    // First chunk is smaller to leave room for create_account + initialize.
+    let first_len = proof_bytes.len().min(RECORD_FIRST_CHUNK);
+    let (first, rest) = proof_bytes.split_at(first_len);
+
+    let mut sigs = Vec::new();
+    let mut offset = 0usize;
+
+    // tx 1: create + initialize + write the first chunk. We never append the
+    // trailing ixs here (create_account + initialize already make this tx the
+    // heaviest), so it can't overflow on a large single-chunk proof.
+    sigs.push(send_tx(
+        client,
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &record_account.pubkey(),
+                rent,
+                space as u64,
+                &spl_record::id(),
+            ),
+            spl_record::instruction::initialize(&record_account.pubkey(), &payer.pubkey()),
+            spl_record::instruction::write(&record_account.pubkey(), &payer.pubkey(), 0, first),
+        ],
+        &[payer, record_account],
+        &payer.pubkey(),
+    )?);
+    offset += first.len();
+
+    // Remaining chunks are write-only; the trailing ixs ride the last one.
+    let mut chunks = rest.chunks(RECORD_WRITE_CHUNK).peekable();
+    let mut trailing_attached = false;
+    while let Some(chunk) = chunks.next() {
+        let mut ixs = vec![spl_record::instruction::write(
+            &record_account.pubkey(),
+            &payer.pubkey(),
+            offset as u64,
+            chunk,
+        )];
+        let mut signers: Vec<&dyn Signer> = vec![payer];
+        if chunks.peek().is_none() {
+            ixs.extend_from_slice(trailing_ixs);
+            signers.extend_from_slice(trailing_signers);
+            trailing_attached = true;
+        }
+        sigs.push(send_tx(client, &ixs, &signers, &payer.pubkey())?);
+        offset += chunk.len();
+    }
+
+    // Single-chunk proof: no write-only tx existed to carry the trailing ixs.
+    if !trailing_attached {
+        let mut signers: Vec<&dyn Signer> = vec![payer];
+        signers.extend_from_slice(trailing_signers);
+        sigs.push(send_tx(client, trailing_ixs, &signers, &payer.pubkey())?);
+    }
+
+    Ok(sigs)
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Common types for confidential transfer operations
 
-use solana_sdk::signature::Signature;
+use solana_signature::Signature;
 use std::error::Error;
 
 /// Result type for confidential transfer operations

--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -9,11 +9,11 @@
 use crate::types::*;
 use solana_address::Address;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signature, Signer},
-    transaction::Transaction,
-};
+use solana_pubkey::Pubkey;
+use solana_keypair::Keypair;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use solana_system_interface::instruction as system_instruction;
 use solana_zk_elgamal_proof_interface::{
     instruction::{close_context_state, ContextStateInfo, ProofInstruction},
@@ -43,7 +43,7 @@ use spl_token_confidential_transfer_proof_generation::withdraw::withdraw_proof_d
 use std::mem::size_of;
 
 const ZK_PROOF_PROGRAM_ID: Pubkey =
-    solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
+    solana_pubkey::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
 
 pub async fn withdraw_from_confidential(
     client: &RpcClient,

--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -1,9 +1,9 @@
-//! Withdraw tokens from confidential balance to public balance (bypass mode).
+//! Withdraw tokens from confidential balance to public balance.
 //!
-//! Generates the equality + range proofs using
+//! Generates the equality + range proofs with
 //! `spl-token-confidential-transfer-proof-generation = 0.6.0`
-//! (`solana-zk-sdk = 6.0.1`), pre-verifies each into a context state account,
-//! then references those accounts in `spl-token-2022 = 10.0.0`'s withdraw ix
+//! (solana-zk-sdk 6.0.1), pre-verifies each into a context state account,
+//! then references those accounts in spl-token-2022 11.0.0's withdraw ix
 //! via `ProofLocation::ContextStateAccount`.
 
 use crate::types::*;
@@ -24,7 +24,7 @@ use solana_zk_sdk::encryption::{
     auth_encryption::AeKey,
     elgamal::{ElGamalCiphertext, ElGamalKeypair},
 };
-use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
+use solana_zk_sdk_pod::encryption::auth_encryption::PodAeCiphertext;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
     extension::{
@@ -36,7 +36,6 @@ use spl_token_2022::{
         },
         BaseStateWithExtensions, StateWithExtensions,
     },
-    solana_zk_sdk::encryption::pod::auth_encryption::PodAeCiphertext as PodAeCiphertextLegacy,
     state::Account as TokenAccount,
 };
 use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
@@ -67,13 +66,8 @@ pub async fn withdraw_from_confidential(
     let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
     let ct_extension = account.get_extension::<ConfidentialTransferAccount>()?;
 
-    // 4.0 PodElGamalCiphertext → 6.0.1 → ElGamalCiphertext.
-    let available_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.available_balance)
-            .try_into()
-            .map_err(|_| "available_balance size")?,
-    );
-    let available_balance: ElGamalCiphertext = available_v6
+    let available_balance: ElGamalCiphertext = ct_extension
+        .available_balance
         .try_into()
         .map_err(|e| format!("decode available_balance: {e:?}"))?;
 
@@ -99,9 +93,7 @@ pub async fn withdraw_from_confidential(
 
     // New decryptable available balance after withdraw.
     let new_available = current_available - amount;
-    let new_decryptable_v6 = aes_key.encrypt(new_available);
-    let new_decryptable_legacy: PodAeCiphertextLegacy =
-        PodAeCiphertextLegacy::from(new_decryptable_v6.to_bytes());
+    let new_decryptable: PodAeCiphertext = aes_key.encrypt(new_available).into();
 
     // ----- Pre-verify equality proof into a context state account -----
     let equality_account = Keypair::new();
@@ -124,11 +116,13 @@ pub async fn withdraw_from_confidential(
         );
 
     let mut signatures: Vec<Signature> = Vec::new();
+    // Verify-with-context-state records the authority as a non-signer for
+    // the later close; only payer + the new proof account need to sign here.
     let blockhash = client.get_latest_blockhash()?;
     let tx = Transaction::new_signed_with_payer(
         &[equality_create_ix, equality_verify_ix],
         Some(&payer.pubkey()),
-        &[payer, authority, &equality_account],
+        &[payer, &equality_account],
         blockhash,
     );
     signatures.push(client.send_and_confirm_transaction(&tx)?);
@@ -156,7 +150,7 @@ pub async fn withdraw_from_confidential(
     let tx = Transaction::new_signed_with_payer(
         &[range_create_ix, range_verify_ix],
         Some(&payer.pubkey()),
-        &[payer, authority, &range_account],
+        &[payer, &range_account],
         blockhash,
     );
     signatures.push(client.send_and_confirm_transaction(&tx)?);
@@ -173,7 +167,7 @@ pub async fn withdraw_from_confidential(
         mint,
         amount,
         decimals,
-        &new_decryptable_legacy,
+        &new_decryptable,
         &authority.pubkey(),
         &[&authority.pubkey()],
         equality_loc,

--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -95,10 +95,20 @@ pub async fn withdraw_from_confidential(
     let new_available = current_available - amount;
     let new_decryptable: PodAeCiphertext = aes_key.encrypt(new_available).into();
 
-    // ----- Pre-verify equality proof into a context state account -----
+    // ----- Pre-verify the proofs into context state accounts -----
+    // Same packing as the transfer flow: the creates + the small equality
+    // verify share one tx, and the range verify gets its own tx (the verify
+    // ix carries the whole proof, so pairing it with anything else overflows
+    // the 1232-byte tx size limit). Payer is the context-state authority so
+    // the verify txs don't carry the token authority's key.
     let equality_account = Keypair::new();
+    let range_account = Keypair::new();
+
     let equality_size = size_of::<ProofContextState<CiphertextCommitmentEqualityProofContext>>();
     let equality_rent = client.get_minimum_balance_for_rent_exemption(equality_size)?;
+    let range_size = size_of::<ProofContextState<BatchedRangeProofContext>>();
+    let range_rent = client.get_minimum_balance_for_rent_exemption(range_size)?;
+
     let equality_create_ix = system_instruction::create_account(
         &payer.pubkey(),
         &equality_account.pubkey(),
@@ -106,31 +116,6 @@ pub async fn withdraw_from_confidential(
         equality_size as u64,
         &ZK_PROOF_PROGRAM_ID,
     );
-    let equality_verify_ix = ProofInstruction::VerifyCiphertextCommitmentEquality
-        .encode_verify_proof(
-            Some(ContextStateInfo {
-                context_state_account: &Address::from(equality_account.pubkey().to_bytes()),
-                context_state_authority: &Address::from(authority.pubkey().to_bytes()),
-            }),
-            &proof_data.equality_proof_data,
-        );
-
-    let mut signatures: Vec<Signature> = Vec::new();
-    // Verify-with-context-state records the authority as a non-signer for
-    // the later close; only payer + the new proof account need to sign here.
-    let blockhash = client.get_latest_blockhash()?;
-    let tx = Transaction::new_signed_with_payer(
-        &[equality_create_ix, equality_verify_ix],
-        Some(&payer.pubkey()),
-        &[payer, &equality_account],
-        blockhash,
-    );
-    signatures.push(client.send_and_confirm_transaction(&tx)?);
-
-    // ----- Pre-verify range proof into a context state account -----
-    let range_account = Keypair::new();
-    let range_size = size_of::<ProofContextState<BatchedRangeProofContext>>();
-    let range_rent = client.get_minimum_balance_for_rent_exemption(range_size)?;
     let range_create_ix = system_instruction::create_account(
         &payer.pubkey(),
         &range_account.pubkey(),
@@ -138,19 +123,42 @@ pub async fn withdraw_from_confidential(
         range_size as u64,
         &ZK_PROOF_PROGRAM_ID,
     );
+
+    let payer_addr: Address = payer.pubkey().to_bytes().into();
+    let equality_verify_ix = ProofInstruction::VerifyCiphertextCommitmentEquality
+        .encode_verify_proof(
+            Some(ContextStateInfo {
+                context_state_account: &Address::from(equality_account.pubkey().to_bytes()),
+                context_state_authority: &payer_addr,
+            }),
+            &proof_data.equality_proof_data,
+        );
     let range_verify_ix = ProofInstruction::VerifyBatchedRangeProofU64.encode_verify_proof(
         Some(ContextStateInfo {
             context_state_account: &Address::from(range_account.pubkey().to_bytes()),
-            context_state_authority: &Address::from(authority.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
         }),
         &proof_data.range_proof_data,
     );
 
+    let mut signatures: Vec<Signature> = Vec::new();
+
+    // Tx 1: create both proof accounts + verify the equality proof.
     let blockhash = client.get_latest_blockhash()?;
     let tx = Transaction::new_signed_with_payer(
-        &[range_create_ix, range_verify_ix],
+        &[equality_create_ix, range_create_ix, equality_verify_ix],
         Some(&payer.pubkey()),
-        &[payer, &range_account],
+        &[payer, &equality_account, &range_account],
+        blockhash,
+    );
+    signatures.push(client.send_and_confirm_transaction(&tx)?);
+
+    // Tx 2: verify the range proof on its own.
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[range_verify_ix],
+        Some(&payer.pubkey()),
+        &[payer],
         blockhash,
     );
     signatures.push(client.send_and_confirm_transaction(&tx)?);
@@ -174,33 +182,35 @@ pub async fn withdraw_from_confidential(
         range_loc,
     )?;
 
+    // Tx 3: withdraw + close both proof accounts. Payer is the context-state
+    // authority on the closes; the token authority signs for the withdraw.
+    let close_eq = close_context_state(
+        ContextStateInfo {
+            context_state_account: &Address::from(equality_account.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
+        },
+        &payer_addr,
+    );
+    let close_range = close_context_state(
+        ContextStateInfo {
+            context_state_account: &Address::from(range_account.pubkey().to_bytes()),
+            context_state_authority: &payer_addr,
+        },
+        &payer_addr,
+    );
+    let mut ixs = withdraw_ixs;
+    ixs.push(close_eq);
+    ixs.push(close_range);
+
     let blockhash = client.get_latest_blockhash()?;
     let tx = Transaction::new_signed_with_payer(
-        &withdraw_ixs,
+        &ixs,
         Some(&payer.pubkey()),
         &[payer, authority],
         blockhash,
     );
-    signatures.push(client.send_and_confirm_transaction(&tx)?);
-
-    // ----- Close the two proof context state accounts -----
-    for account in [&equality_account, &range_account] {
-        let close_ix = close_context_state(
-            ContextStateInfo {
-                context_state_account: &Address::from(account.pubkey().to_bytes()),
-                context_state_authority: &Address::from(authority.pubkey().to_bytes()),
-            },
-            &Address::from(payer.pubkey().to_bytes()),
-        );
-        let blockhash = client.get_latest_blockhash()?;
-        let tx = Transaction::new_signed_with_payer(
-            &[close_ix],
-            Some(&payer.pubkey()),
-            &[payer, authority],
-            blockhash,
-        );
-        signatures.push(client.send_and_confirm_transaction(&tx)?);
-    }
+    let withdraw_sig = client.send_and_confirm_transaction(&tx)?;
+    signatures.push(withdraw_sig);
 
     println!(
         "✅ Withdrew {} tokens to public balance ({} txs). Remaining confidential: {}",
@@ -208,6 +218,5 @@ pub async fn withdraw_from_confidential(
         signatures.len(),
         new_available
     );
-    // Return the withdraw ix signature (index 2 in the sequence).
-    Ok(signatures[2])
+    Ok(withdraw_sig)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,11 +2,10 @@
 
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_sdk::{
-    native_token::LAMPORTS_PER_SOL,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 use solana_system_interface::instruction as system_instruction;
 use spl_associated_token_account::{
     get_associated_token_address_with_program_id,
@@ -80,7 +79,7 @@ impl TestEnv {
     }
 
     /// Request airdrop if on local test validator, or transfer from payer on custom cluster
-    pub fn airdrop_if_needed(&self, pubkey: &solana_sdk::pubkey::Pubkey, lamports: u64) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn airdrop_if_needed(&self, pubkey: &solana_pubkey::Pubkey, lamports: u64) -> Result<(), Box<dyn std::error::Error>> {
         if !self.is_local {
             // Skip if trying to fund the payer itself (it's already funded)
             if pubkey == &self.payer.pubkey() {
@@ -140,7 +139,7 @@ impl TestEnv {
     }
 
     /// Get payer's public key
-    pub fn payer_pubkey(&self) -> solana_sdk::pubkey::Pubkey {
+    pub fn payer_pubkey(&self) -> solana_pubkey::Pubkey {
         self.payer.pubkey()
     }
 }
@@ -217,9 +216,9 @@ pub fn create_confidential_mint(
 /// Create an associated token account
 pub fn create_token_account(
     env: &TestEnv,
-    mint: &solana_sdk::pubkey::Pubkey,
-    owner: &solana_sdk::pubkey::Pubkey,
-) -> Result<solana_sdk::pubkey::Pubkey, Box<dyn std::error::Error>> {
+    mint: &solana_pubkey::Pubkey,
+    owner: &solana_pubkey::Pubkey,
+) -> Result<solana_pubkey::Pubkey, Box<dyn std::error::Error>> {
     let token_account = get_associated_token_address_with_program_id(
         owner,
         mint,
@@ -252,8 +251,8 @@ pub fn create_token_account(
 /// Mint tokens to an account
 pub fn mint_tokens(
     env: &TestEnv,
-    mint: &solana_sdk::pubkey::Pubkey,
-    destination: &solana_sdk::pubkey::Pubkey,
+    mint: &solana_pubkey::Pubkey,
+    destination: &solana_pubkey::Pubkey,
     authority: &Keypair,
     amount: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,13 +12,13 @@ use spl_associated_token_account::{
     get_associated_token_address_with_program_id,
     instruction::create_associated_token_account,
 };
+use solana_zk_sdk::encryption::elgamal::ElGamalKeypair;
 use spl_token_2022::{
     extension::{
         confidential_transfer::instruction::initialize_mint,
         ExtensionType,
     },
     instruction::initialize_mint as initialize_mint_base,
-    solana_zk_sdk::encryption::elgamal::ElGamalKeypair,
     state::Mint,
 };
 use std::env;
@@ -179,8 +179,7 @@ pub fn create_confidential_mint(
     );
 
     // Initialize confidential transfer extension
-    // Convert ElGamalPubkey to PodElGamalPubkey
-    let auditor_pubkey_pod: spl_token_2022::solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey =
+    let auditor_pubkey_pod: solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey =
         (*auditor_elgamal.pubkey()).into();
 
     let init_ct_ix = initialize_mint(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,7 +16,8 @@ mod common;
 
 use common::*;
 use conf_balances_examples::*;
-use solana_sdk::signature::{Keypair, Signer};
+use solana_keypair::Keypair;
+use solana_signer::Signer;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_configure_account() {


### PR DESCRIPTION
The exploration repo got archived with three pieces of work that never landed on its main, so this ports all of them here, rebased onto each other and adapted where the codebases had diverged.

**Agave v4 migration** (exploration PRs #3 + #4, merged there to devnet-v6 but never to main): token-2022 11 and the proof crates target solana-zk-sdk 6.0.1 natively, so the whole 4.0/6.0.1 bypass is gone: no byte-casting, no spl-record staging for the U128 range proof, and the single transfer condenses from 5 txs to 3. Uses granular Solana crates on the rc line instead of the sdk umbrella. These cherry-picked almost cleanly; the conflict against the signing fix resolved in favor of the agave version since it already bakes in the same lessons (payer as context-state authority, tx size packing).

**Batch transfers** (exploration PR #6): the offline proof chaining logic carried over as is, but the staging layer was written against bypass-mode internals, so it's rewritten in the agave style: no record accounts (the U128 range proof verify fits in its own tx with payer as context authority), pod types convert with try_into, and stage_leg is 3 txs per leg. Also fixed the ALT create to anchor on a finalized slot; the confirmed slot was intermittently rejected with "not a recent slot".

**Fees + permanent delegate** (exploration PR #1 by @MicaiahReid): this one predates even the bypass era and was built on the spl-token-client Token helper the migration dropped, so it's a reimplementation rather than a cherry-pick, and it's additive: the plain transfer path stays untouched, and the fee flow lives in transfer_with_fee.rs + run_transfer_with_fees.rs. Five proofs, with the U256 range proof staged through an spl-record account since its verify ix alone exceeds the tx size limit. The example demonstrates the withheld fee decrypting to exactly 1% on the recipient, harvest to mint, and a permanent-delegate burn without the recipient's signature. Along the way this surfaced that withdraw.rs overflowed the tx size limit (never exercised before), fixed by repacking its proof txs.

**Everything verified on devnet**, not just compiled:
- plain transfer: 3 txs ([mint](https://explorer.solana.com/address/DgKQ8wMjKaeaopwHBqXCLDs87McvVPbb7wWGopmiC3sD?cluster=devnet))
- atomic batch: 3 legs in one v0 tx ([tx](https://explorer.solana.com/tx/B1XMGbcAJpLRda5Y9hUm1C1QsjWr3Jftr1AEvNbZV4v3obUBVZXzZBwcToXtr9ZoRUECvPLsf4CS9rNqkfTiSgc?cluster=devnet)), pipelined: 4 legs
- fee transfer: 8 txs, fee = 500,000 on 50,000,000 at 100 bps, verified on the recipient account and again on the mint after harvest ([mint](https://explorer.solana.com/address/45fSFHpyxPuyb1uu3L7FMEdC2NRgDWd53hShjbQ5Ff6T?cluster=devnet))
- withdraw + delegate burn on the same run