### PR TITLE
fix: Address Greptile review on the confidential balances workshop

### DIFF
--- a/src/apply_pending.rs
+++ b/src/apply_pending.rs
@@ -8,7 +8,10 @@
 use crate::types::*;
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{signature::Signer, transaction::Transaction};
-use solana_zk_sdk::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair};
+use solana_zk_sdk::encryption::{
+    auth_encryption::{AeCiphertext, AeKey},
+    elgamal::ElGamalKeypair,
+};
 use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
@@ -43,7 +46,8 @@ pub async fn apply_pending_balance(
     let account = StateWithExtensions::<TokenAccount>::unpack(&account_data.data)?;
     let ct_extension = account.get_extension::<ConfidentialTransferAccount>()?;
 
-    // Byte-cast 4.0 PodElGamalCiphertext → 6.0.1 → ElGamalCiphertext.
+    // Byte-cast the 4.0 pending-balance ciphertexts to 6.0.1 and decrypt with
+    // the ElGamal key. Pending lo/hi are bounded, so decrypt_u32 is fine here.
     let pending_lo_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
         bytemuck::bytes_of(&ct_extension.pending_balance_lo)
             .try_into()
@@ -54,35 +58,35 @@ pub async fn apply_pending_balance(
             .try_into()
             .map_err(|_| "pending_balance_hi size")?,
     );
-    let available_v6: PodElGamalCiphertextV6 = PodElGamalCiphertextV6(
-        bytemuck::bytes_of(&ct_extension.available_balance)
-            .try_into()
-            .map_err(|_| "available_balance size")?,
-    );
-
     let pending_lo: solana_zk_sdk::encryption::elgamal::ElGamalCiphertext =
         pending_lo_v6.try_into().map_err(|e| format!("{e:?}"))?;
     let pending_hi: solana_zk_sdk::encryption::elgamal::ElGamalCiphertext =
         pending_hi_v6.try_into().map_err(|e| format!("{e:?}"))?;
-    let available_balance: solana_zk_sdk::encryption::elgamal::ElGamalCiphertext =
-        available_v6.try_into().map_err(|e| format!("{e:?}"))?;
-
     let pending_lo_amount = pending_lo
         .decrypt_u32(elgamal_keypair.secret())
-        .ok_or("decrypt pending_balance_lo")?;
+        .ok_or("decrypt pending_balance_lo")? as u64;
     let pending_hi_amount = pending_hi
         .decrypt_u32(elgamal_keypair.secret())
-        .ok_or("decrypt pending_balance_hi")?;
-    let current_available = available_balance
-        .decrypt_u32(elgamal_keypair.secret())
-        .ok_or("decrypt available_balance")?;
+        .ok_or("decrypt pending_balance_hi")? as u64;
+
+    // Read the current available balance from the AES-encrypted decryptable
+    // balance. ElGamal's decrypt_u32 only recovers values up to 2^32 raw units,
+    // so it fails for realistic balances; the AES field has no such limit.
+    let decryptable_bytes: [u8; 36] =
+        bytemuck::bytes_of(&ct_extension.decryptable_available_balance)
+            .try_into()
+            .map_err(|_| "decryptable_available_balance size")?;
+    let current_available = AeCiphertext::from_bytes(&decryptable_bytes)
+        .ok_or("decode decryptable_available_balance")?
+        .decrypt(&aes_key)
+        .ok_or("decrypt available balance")?;
 
     let pending_total = pending_lo_amount + (pending_hi_amount << 16);
     let new_available = current_available + pending_total;
 
     // Encrypt new available with 6.0.1 AES, byte-cast to legacy PodAeCiphertext
     // for the spl-token-2022 instruction builder.
-    let new_decryptable_v6 = aes_key.encrypt(new_available as u64);
+    let new_decryptable_v6 = aes_key.encrypt(new_available);
     let new_decryptable_legacy: PodAeCiphertextLegacy =
         PodAeCiphertextLegacy::from(new_decryptable_v6.to_bytes());
 

--- a/src/bin/demo-server.rs
+++ b/src/bin/demo-server.rs
@@ -514,7 +514,9 @@ async fn transfer_handler(
             }
         };
 
-        if let Some(transfer_sig) = sigs.get(3) {
+        // The U128 range proof stages into two spl-record write txs, so the
+        // transfer (with its bundled closes) is the last signature, not index 3.
+        if let Some(transfer_sig) = sigs.last() {
             log_event(&s, "transfer", amount_ui, transfer_sig).await;
         }
 
@@ -834,8 +836,7 @@ async fn read_ledger_state(s: &AppState) -> Result<LedgerState> {
         receiver,
         auditor: AuditorView {
             authority: s.keys.auditor_authority.pubkey().to_string(),
-            elgamal_pubkey: bs58::encode(s.auditor_elgamal.pubkey().to_string().as_bytes())
-                .into_string(),
+            elgamal_pubkey: s.auditor_elgamal.pubkey().to_string(),
             recent_events: events,
         },
     })

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -38,9 +38,6 @@ use spl_token_2022::{
 use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
 use std::mem::size_of;
 
-const ZK_PROOF_PROGRAM_ID: Pubkey =
-    solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
-
 pub async fn configure_account_for_confidential_transfers(
     client: &RpcClient,
     payer: &dyn Signer,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -56,9 +56,6 @@ use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation
 use spl_token_confidential_transfer_proof_generation::transfer::transfer_split_proof_data;
 use std::mem::size_of;
 
-const ZK_PROOF_PROGRAM_ID: Pubkey =
-    solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
-
 /// Byte offset of the proof data inside an spl-record account
 /// (`RecordData::WRITABLE_START_INDEX`: 1-byte version + 32-byte authority).
 const RECORD_PROOF_OFFSET: u32 = 33;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,12 @@
 //! Common types for confidential transfer operations
 
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use std::error::Error;
+
+/// The native ZK ElGamal Proof program that verifies confidential-transfer proofs.
+pub const ZK_PROOF_PROGRAM_ID: Pubkey =
+    solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
 
 /// Result type for confidential transfer operations
 pub type CtResult<T> = Result<T, Box<dyn Error>>;

--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -21,7 +21,7 @@ use solana_zk_elgamal_proof_interface::{
     state::ProofContextState,
 };
 use solana_zk_sdk::encryption::{
-    auth_encryption::AeKey,
+    auth_encryption::{AeCiphertext, AeKey},
     elgamal::{ElGamalCiphertext, ElGamalKeypair},
 };
 use solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext as PodElGamalCiphertextV6;
@@ -42,9 +42,6 @@ use spl_token_2022::{
 use spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation;
 use spl_token_confidential_transfer_proof_generation::withdraw::withdraw_proof_data;
 use std::mem::size_of;
-
-const ZK_PROOF_PROGRAM_ID: Pubkey =
-    solana_sdk::pubkey!("ZkE1Gama1Proof11111111111111111111111111111");
 
 pub async fn withdraw_from_confidential(
     client: &RpcClient,
@@ -77,9 +74,17 @@ pub async fn withdraw_from_confidential(
         .try_into()
         .map_err(|e| format!("decode available_balance: {e:?}"))?;
 
-    let current_available = available_balance
-        .decrypt_u32(elgamal_keypair.secret())
-        .ok_or("decrypt available balance")? as u64;
+    // Read the plaintext balance from the AES-encrypted decryptable balance.
+    // ElGamal's decrypt_u32 only recovers values up to 2^32 raw units, so it
+    // fails for realistic balances; the AES field has no such limit.
+    let decryptable_bytes: [u8; 36] =
+        bytemuck::bytes_of(&ct_extension.decryptable_available_balance)
+            .try_into()
+            .map_err(|_| "decryptable_available_balance size")?;
+    let current_available = AeCiphertext::from_bytes(&decryptable_bytes)
+        .ok_or("decode decryptable_available_balance")?
+        .decrypt(&aes_key)
+        .ok_or("decrypt available balance")?;
 
     if current_available < amount {
         return Err(format!(


### PR DESCRIPTION
Addresses the Greptile review on #4, as a focused diff on top of the migration branch. All four are confirmed real (verified against the code); `cargo check --all-targets` passes.

### Data-correctness bugs (visible on the live demo)
- **Transfer event logs the wrong signature** (`demo-server.rs`): `sigs.get(3)` is the second range-proof staging tx, not the transfer. The U128 range proof stages into two spl-record writes, so signatures are `[equality, validity, range-stage-1, range-stage-2, transfer-and-close]` and the transfer is `sigs.last()`.
- **Auditor ElGamal pubkey double-encoded** (`demo-server.rs`): `bs58::encode(pubkey().to_string().as_bytes())` base58-encoded the ASCII of an already-stringified key, producing a garbled value in every `/demo/state` response. Now returns `pubkey().to_string()` directly, consistent with the other pubkey fields.

### Correctness
- **`decrypt_u32` range limit** (`apply_pending.rs`, `withdraw.rs`): reading the available balance via ElGamal `decrypt_u32` (baby-step-giant-step) caps at ~2^32 raw units and returns `None` for realistic balances (a 9-decimal token holding a few tokens already exceeds it). Both now read the AES-encrypted `decryptable_available_balance`, which has no range limit — matching what `transfer.rs` already does. Pending lo/hi stay on `decrypt_u32` (bounded), and the apply-pending accumulation is now `u64`.

### Cleanup
- **Deduplicate `ZK_PROOF_PROGRAM_ID`**: defined once in `types.rs` and reused across `configure`/`transfer`/`withdraw` instead of three copies.

Deferred (low priority): the `AccountNotFound` string-match robustness nit — the string match works today; switching to a JSON-RPC error-code match is a follow-up.